### PR TITLE
feat: add Courses as a booking payment method

### DIFF
--- a/apps/atnd-me/src/app/(frontend)/bookings/[id]/manage/page.tsx
+++ b/apps/atnd-me/src/app/(frontend)/bookings/[id]/manage/page.tsx
@@ -58,7 +58,8 @@ export default async function ManageBookingPage({ params }: ManageBookingPagePro
       pm?.allowedDropIn ||
         (Array.isArray(pm?.allowedPlans) && (pm.allowedPlans as unknown[]).length > 0) ||
         (Array.isArray(pm?.allowedClassPasses) &&
-          (pm.allowedClassPasses as unknown[]).length > 0),
+          (pm.allowedClassPasses as unknown[]).length > 0) ||
+        (Array.isArray(pm?.allowedCourses) && (pm.allowedCourses as unknown[]).length > 0),
     )
 
     if (initialCheckoutHold === null && timeslotHasPaymentMethods) {

--- a/apps/atnd-me/src/app/(frontend)/courses/[slug]/page.tsx
+++ b/apps/atnd-me/src/app/(frontend)/courses/[slug]/page.tsx
@@ -14,7 +14,7 @@ export default async function CourseDetailPage({ params }: PageProps) {
   if (!result) notFound()
 
   return (
-    <div className="container mx-auto max-w-5xl px-4">
+    <div className="container mx-auto">
       <CourseDetailView
         course={result.course}
         activeEnrollmentCount={result.activeEnrollmentCount}

--- a/apps/atnd-me/src/app/(frontend)/courses/[slug]/page.tsx
+++ b/apps/atnd-me/src/app/(frontend)/courses/[slug]/page.tsx
@@ -1,0 +1,24 @@
+import { notFound } from 'next/navigation'
+import { CourseDetailView } from '@/components/courses/CourseDetailView'
+import { queryCourseBySlug } from '../queryCourses'
+
+export const dynamic = 'force-dynamic'
+
+type PageProps = {
+  params: Promise<{ slug: string }>
+}
+
+export default async function CourseDetailPage({ params }: PageProps) {
+  const { slug } = await params
+  const result = await queryCourseBySlug(slug)
+  if (!result) notFound()
+
+  return (
+    <div className="container mx-auto max-w-5xl px-4">
+      <CourseDetailView
+        course={result.course}
+        activeEnrollmentCount={result.activeEnrollmentCount}
+      />
+    </div>
+  )
+}

--- a/apps/atnd-me/src/app/(frontend)/courses/page.tsx
+++ b/apps/atnd-me/src/app/(frontend)/courses/page.tsx
@@ -20,7 +20,7 @@ export default async function CoursesPage() {
       {courses.length === 0 ? (
         <p className="mt-8 text-sm text-muted-foreground">No courses are open right now.</p>
       ) : (
-        <ul className="mt-8 space-y-4" data-testid="courses-list">
+        <ul className="mt-8 max-w-xl space-y-4" data-testid="courses-list">
           {courses.map((course) => {
             const windowCopy = formatCourseAccessWindowCopy(course)
             const price =

--- a/apps/atnd-me/src/app/(frontend)/courses/page.tsx
+++ b/apps/atnd-me/src/app/(frontend)/courses/page.tsx
@@ -1,6 +1,9 @@
+import Image from 'next/image'
 import Link from 'next/link'
 import { queryOpenCourses } from './queryCourses'
 import { formatCourseAccessWindowCopy } from '@/lib/courses/format-course-access-window'
+import { mediaUrl } from '@/components/events/eventPageTypes'
+import type { Media } from '@/payload-types'
 
 export const dynamic = 'force-dynamic'
 
@@ -8,7 +11,7 @@ export default async function CoursesPage() {
   const courses = await queryOpenCourses()
 
   return (
-    <div className="container mx-auto max-w-3xl px-4 pt-24 pb-12">
+    <div className="container mx-auto pt-24 pb-12">
       <h1 className="text-3xl font-bold tracking-tight text-foreground">Courses</h1>
       <p className="mt-2 text-muted-foreground">
         Enroll in a course to book allowed classes during your access window.
@@ -24,22 +27,42 @@ export default async function CoursesPage() {
               typeof course.priceInformation?.price === 'number'
                 ? course.priceInformation.price
                 : null
+            const cover =
+              course.coverImage && typeof course.coverImage === 'object'
+                ? (course.coverImage as Media)
+                : null
+            const coverUrl = mediaUrl(cover)
             return (
               <li key={course.id}>
                 <Link
                   href={`/courses/${course.slug}`}
-                  className="block rounded-xl border border-border px-4 py-4 transition hover:bg-muted/40"
+                  className="flex gap-4 rounded-xl border border-border px-4 py-4 transition hover:bg-muted/40"
                   data-testid="course-list-item"
                 >
-                  <div className="flex items-baseline justify-between gap-3">
-                    <h2 className="text-lg font-semibold text-foreground">{course.title}</h2>
-                    {price != null ? (
-                      <span className="text-base font-semibold tabular-nums">€{price.toFixed(2)}</span>
+                  {coverUrl ? (
+                    <div className="relative h-20 w-28 shrink-0 overflow-hidden rounded-lg">
+                      <Image
+                        src={coverUrl}
+                        alt={cover?.alt || course.title || 'Course'}
+                        fill
+                        sizes="112px"
+                        className="object-cover"
+                      />
+                    </div>
+                  ) : null}
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-baseline justify-between gap-3">
+                      <h2 className="text-lg font-semibold text-foreground">{course.title}</h2>
+                      {price != null ? (
+                        <span className="text-base font-semibold tabular-nums">
+                          €{price.toFixed(2)}
+                        </span>
+                      ) : null}
+                    </div>
+                    {windowCopy ? (
+                      <p className="mt-1 text-sm text-muted-foreground">{windowCopy}</p>
                     ) : null}
                   </div>
-                  {windowCopy ? (
-                    <p className="mt-1 text-sm text-muted-foreground">{windowCopy}</p>
-                  ) : null}
                 </Link>
               </li>
             )

--- a/apps/atnd-me/src/app/(frontend)/courses/page.tsx
+++ b/apps/atnd-me/src/app/(frontend)/courses/page.tsx
@@ -1,0 +1,51 @@
+import Link from 'next/link'
+import { queryOpenCourses } from './queryCourses'
+import { formatCourseAccessWindowCopy } from '@/lib/courses/format-course-access-window'
+
+export const dynamic = 'force-dynamic'
+
+export default async function CoursesPage() {
+  const courses = await queryOpenCourses()
+
+  return (
+    <div className="container mx-auto max-w-3xl px-4 pt-24 pb-12">
+      <h1 className="text-3xl font-bold tracking-tight text-foreground">Courses</h1>
+      <p className="mt-2 text-muted-foreground">
+        Enroll in a course to book allowed classes during your access window.
+      </p>
+
+      {courses.length === 0 ? (
+        <p className="mt-8 text-sm text-muted-foreground">No courses are open right now.</p>
+      ) : (
+        <ul className="mt-8 space-y-4" data-testid="courses-list">
+          {courses.map((course) => {
+            const windowCopy = formatCourseAccessWindowCopy(course)
+            const price =
+              typeof course.priceInformation?.price === 'number'
+                ? course.priceInformation.price
+                : null
+            return (
+              <li key={course.id}>
+                <Link
+                  href={`/courses/${course.slug}`}
+                  className="block rounded-xl border border-border px-4 py-4 transition hover:bg-muted/40"
+                  data-testid="course-list-item"
+                >
+                  <div className="flex items-baseline justify-between gap-3">
+                    <h2 className="text-lg font-semibold text-foreground">{course.title}</h2>
+                    {price != null ? (
+                      <span className="text-base font-semibold tabular-nums">€{price.toFixed(2)}</span>
+                    ) : null}
+                  </div>
+                  {windowCopy ? (
+                    <p className="mt-1 text-sm text-muted-foreground">{windowCopy}</p>
+                  ) : null}
+                </Link>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/apps/atnd-me/src/app/(frontend)/courses/queryCourses.ts
+++ b/apps/atnd-me/src/app/(frontend)/courses/queryCourses.ts
@@ -22,7 +22,7 @@ export const queryOpenCourses = cache(async (): Promise<CourseDetailDoc[]> => {
     },
     sort: 'title',
     limit: 50,
-    depth: 0,
+    depth: 1,
     overrideAccess: true,
   })
 
@@ -48,7 +48,7 @@ export const queryCourseBySlug = cache(
         ],
       },
       limit: 1,
-      depth: 0,
+      depth: 1,
       overrideAccess: true,
     })
 

--- a/apps/atnd-me/src/app/(frontend)/courses/queryCourses.ts
+++ b/apps/atnd-me/src/app/(frontend)/courses/queryCourses.ts
@@ -1,0 +1,74 @@
+import { cache } from 'react'
+import { cookies, headers } from 'next/headers'
+import { getPayload } from '@/lib/payload'
+import { getTenantContext } from '@/utilities/getTenantContext'
+import type { CourseDetailDoc } from '@/components/courses/CourseDetailView'
+
+export const queryOpenCourses = cache(async (): Promise<CourseDetailDoc[]> => {
+  const cookieStore = await cookies()
+  const headersList = await headers()
+  const payload = await getPayload()
+  const tenant = await getTenantContext(payload, { cookies: cookieStore, headers: headersList })
+  const tenantId = tenant?.id
+  if (tenantId == null) return []
+
+  const result = await payload.find({
+    collection: 'courses' as import('payload').CollectionSlug,
+    where: {
+      and: [
+        { tenant: { equals: tenantId } },
+        { status: { equals: 'open' } },
+      ],
+    },
+    sort: 'title',
+    limit: 50,
+    depth: 0,
+    overrideAccess: true,
+  })
+
+  return result.docs as CourseDetailDoc[]
+})
+
+export const queryCourseBySlug = cache(
+  async (slug: string): Promise<{ course: CourseDetailDoc; activeEnrollmentCount: number } | null> => {
+    const cookieStore = await cookies()
+    const headersList = await headers()
+    const payload = await getPayload()
+    const tenant = await getTenantContext(payload, { cookies: cookieStore, headers: headersList })
+    const tenantId = tenant?.id
+    if (tenantId == null) return null
+
+    const result = await payload.find({
+      collection: 'courses' as import('payload').CollectionSlug,
+      where: {
+        and: [
+          { tenant: { equals: tenantId } },
+          { slug: { equals: slug } },
+          { status: { not_equals: 'archived' } },
+        ],
+      },
+      limit: 1,
+      depth: 0,
+      overrideAccess: true,
+    })
+
+    const course = result.docs[0] as CourseDetailDoc | undefined
+    if (!course) return null
+
+    const enrollments = await payload.find({
+      collection: 'course-enrollments' as import('payload').CollectionSlug,
+      where: {
+        and: [
+          { course: { equals: course.id } },
+          { tenant: { equals: tenantId } },
+          { status: { equals: 'active' } },
+        ],
+      },
+      limit: 0,
+      depth: 0,
+      overrideAccess: true,
+    })
+
+    return { course, activeEnrollmentCount: enrollments.totalDocs ?? 0 }
+  },
+)

--- a/apps/atnd-me/src/app/(payload)/admin/importMap.js
+++ b/apps/atnd-me/src/app/(payload)/admin/importMap.js
@@ -36,7 +36,7 @@ import { BoldFeatureClient as BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864
 import { ItalicFeatureClient as ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { EventTypeForTimeslotFilterField as EventTypeForTimeslotFilterField_10c71e90c03730207bbccc04ef112f49 } from '@/components/admin/EventTypeForTimeslotFilterField'
 import { TimeslotDateFilterField as TimeslotDateFilterField_02ebab356a1783b4fbef5c0ad75bbbb0 } from '@/components/admin/TimeslotDateFilterField'
-import { TimeslotForEventPickerField as TimeslotForEventPickerField_a1b2c3d4e5f6789012345678abcdef01 } from '@/components/admin/TimeslotForEventPickerField'
+import { TimeslotForEventPickerField as TimeslotForEventPickerField_30010d743d69d391c01c7a27c3b2dbf7 } from '@/components/admin/TimeslotForEventPickerField'
 import { default as default_ce6f29e70fd4204b43c477b4bf07b84b } from '@/components/admin/DomainDnsInstructions'
 import { default as default_a5117e5f562e81a9d1ce48d0eee41679 } from '@/components/admin/ApexDnsInstructions'
 import { default as default_33fe04c6d27fadf8c7acaa77721ae6da } from '@/components/admin/StripeConnectStatus'
@@ -135,7 +135,7 @@ export const importMap = {
   "@payloadcms/richtext-lexical/client#ItalicFeatureClient": ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@/components/admin/EventTypeForTimeslotFilterField#EventTypeForTimeslotFilterField": EventTypeForTimeslotFilterField_10c71e90c03730207bbccc04ef112f49,
   "@/components/admin/TimeslotDateFilterField#TimeslotDateFilterField": TimeslotDateFilterField_02ebab356a1783b4fbef5c0ad75bbbb0,
-  "@/components/admin/TimeslotForEventPickerField#TimeslotForEventPickerField": TimeslotForEventPickerField_a1b2c3d4e5f6789012345678abcdef01,
+  "@/components/admin/TimeslotForEventPickerField#TimeslotForEventPickerField": TimeslotForEventPickerField_30010d743d69d391c01c7a27c3b2dbf7,
   "@/components/admin/DomainDnsInstructions#default": default_ce6f29e70fd4204b43c477b4bf07b84b,
   "@/components/admin/ApexDnsInstructions#default": default_a5117e5f562e81a9d1ce48d0eee41679,
   "@/components/admin/StripeConnectStatus#default": default_33fe04c6d27fadf8c7acaa77721ae6da,

--- a/apps/atnd-me/src/app/api/courses/guest-checkout/route.ts
+++ b/apps/atnd-me/src/app/api/courses/guest-checkout/route.ts
@@ -1,0 +1,207 @@
+/**
+ * Guest course checkout: ensureGuestUser + PaymentIntent for course enrollment.
+ * No timeslot hold — capacity checked at intent + webhook time.
+ */
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+import { getPayload } from '@/lib/payload'
+import { ensureGuestUser } from '@/lib/booking/ensureGuestUser'
+import { createTenantPaymentIntent } from '@/lib/stripe-connect/charges'
+import {
+  resolveTenantSlugOrId,
+  resolveTenantForConnect,
+} from '@/lib/stripe-connect/api-helpers'
+import { isStripeTestAccount } from '@/lib/stripe-connect/test-accounts'
+import { ensureStripeCustomerIdForAccount } from '@repo/bookings-payments'
+import { checkRateLimit } from '@/lib/onboarding/rateLimit'
+import {
+  isCompleteGuestEmail,
+  resolveCourseForPurchase,
+  type CourseForPurchase,
+} from '@/lib/courses/resolve-course-for-purchase'
+
+export const dynamic = 'force-dynamic'
+
+function clientIp(request: NextRequest): string {
+  const forwarded = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim()
+  return forwarded || request.headers.get('x-real-ip') || 'unknown'
+}
+
+export async function POST(request: NextRequest) {
+  const payload = await getPayload()
+
+  const body = await request.json().catch(() => null)
+  if (!body || typeof body !== 'object') {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const metadata =
+    body.metadata && typeof body.metadata === 'object'
+      ? (body.metadata as Record<string, unknown>)
+      : null
+  const courseIdRaw = body.courseId ?? metadata?.courseId
+  const courseId =
+    typeof courseIdRaw === 'number'
+      ? courseIdRaw
+      : typeof courseIdRaw === 'string'
+        ? parseInt(courseIdRaw, 10)
+        : undefined
+  if (courseId == null || !Number.isFinite(courseId) || courseId < 1) {
+    return NextResponse.json(
+      { error: 'courseId required and must be a positive integer' },
+      { status: 400 },
+    )
+  }
+
+  const guestNameRaw =
+    typeof metadata?.guestName === 'string'
+      ? metadata.guestName
+      : typeof body.guestName === 'string'
+        ? body.guestName
+        : ''
+  const guestEmailRaw =
+    typeof metadata?.guestEmail === 'string'
+      ? metadata.guestEmail
+      : typeof body.guestEmail === 'string'
+        ? body.guestEmail
+        : ''
+  const guestName = guestNameRaw.trim()
+  const guestEmail = guestEmailRaw.trim().toLowerCase()
+
+  if (!guestName || guestName.length < 2) {
+    return NextResponse.json({ error: 'Name is required' }, { status: 400 })
+  }
+  if (!isCompleteGuestEmail(guestEmail)) {
+    return NextResponse.json({ error: 'A valid email is required' }, { status: 400 })
+  }
+
+  const ip = clientIp(request)
+  const ipLimit = checkRateLimit({
+    key: `course-guest-checkout:ip:${ip}`,
+    limit: 20,
+    windowMs: 60 * 60 * 1000,
+  })
+  if (!ipLimit.allowed) {
+    return NextResponse.json(
+      { error: 'Too many requests. Please try again later.' },
+      { status: 429 },
+    )
+  }
+  const emailLimit = checkRateLimit({
+    key: `course-guest-checkout:email:${guestEmail}`,
+    limit: 10,
+    windowMs: 60 * 60 * 1000,
+  })
+  if (!emailLimit.allowed) {
+    return NextResponse.json(
+      { error: 'Too many requests. Please try again later.' },
+      { status: 429 },
+    )
+  }
+
+  const tenantSlugOrId = resolveTenantSlugOrId(request)
+  if (!tenantSlugOrId) {
+    return NextResponse.json(
+      { error: 'Tenant context required (x-tenant-slug / x-tenant-id / tenant-slug cookie)' },
+      { status: 400 },
+    )
+  }
+
+  const tenant = await resolveTenantForConnect(payload, String(tenantSlugOrId))
+  if (!tenant) {
+    return NextResponse.json({ error: 'Tenant not found' }, { status: 404 })
+  }
+
+  if (!tenant.stripeConnectAccountId || tenant.stripeConnectOnboardingStatus !== 'active') {
+    return NextResponse.json({ error: 'Tenant is not connected to Stripe' }, { status: 400 })
+  }
+
+  const course = (await payload
+    .findByID({
+      collection: 'courses' as import('payload').CollectionSlug,
+      id: courseId,
+      depth: 0,
+      overrideAccess: true,
+    })
+    .catch(() => null)) as CourseForPurchase | null
+
+  const activeCount = await payload.find({
+    collection: 'course-enrollments' as import('payload').CollectionSlug,
+    where: {
+      and: [
+        { course: { equals: courseId } },
+        { tenant: { equals: tenant.id } },
+        { status: { equals: 'active' } },
+      ],
+    },
+    limit: 0,
+    depth: 0,
+    overrideAccess: true,
+  })
+
+  const resolved = resolveCourseForPurchase({
+    course,
+    expectedTenantId: tenant.id,
+    activeEnrollmentCount: activeCount.totalDocs ?? 0,
+  })
+  if (!resolved.ok) {
+    return NextResponse.json({ error: resolved.error }, { status: resolved.status })
+  }
+
+  const guest = await ensureGuestUser({
+    payload,
+    email: guestEmail,
+    name: guestName,
+    tenantId: tenant.id,
+  })
+
+  const placeholderAccount = /^acct_[a-z0-9_]+$/.test(
+    tenant.stripeConnectAccountId?.trim() ?? '',
+  )
+  if (isStripeTestAccount(tenant.stripeConnectAccountId) || placeholderAccount) {
+    const mockId = `pi_test_${Date.now()}`
+    return NextResponse.json({
+      clientSecret: `${mockId}_secret_test`,
+      stripeAccountId: tenant.stripeConnectAccountId,
+    })
+  }
+
+  try {
+    const { stripeCustomerId } = await ensureStripeCustomerIdForAccount({
+      payload,
+      userId: guest.userId,
+      email: guestEmail,
+      name: guestName,
+      stripeAccountId: tenant.stripeConnectAccountId,
+    })
+
+    const { client_secret } = await createTenantPaymentIntent({
+      tenant: {
+        id: tenant.id,
+        stripeConnectAccountId: tenant.stripeConnectAccountId,
+        stripeConnectOnboardingStatus: tenant.stripeConnectOnboardingStatus,
+      },
+      classPriceAmount: resolved.priceCents,
+      currency: 'eur',
+      productType: 'course',
+      payload,
+      customerId: stripeCustomerId,
+      metadata: {
+        type: 'course_purchase',
+        userId: String(guest.userId),
+        tenantId: String(tenant.id),
+        courseId: String(courseId),
+        guestCheckout: 'true',
+      },
+    })
+
+    return NextResponse.json({
+      clientSecret: client_secret,
+      stripeAccountId: tenant.stripeConnectAccountId,
+    })
+  } catch (e) {
+    const message = e instanceof Error ? e.message : 'Payment intent failed'
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}

--- a/apps/atnd-me/src/app/api/courses/purchase/route.ts
+++ b/apps/atnd-me/src/app/api/courses/purchase/route.ts
@@ -1,0 +1,147 @@
+/**
+ * Authenticated course purchase: create PaymentIntent for course enrollment.
+ * Tenant from context (slug/header). Enrollment is created by webhook on payment success.
+ */
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+import { getPayload } from '@/lib/payload'
+import { createTenantPaymentIntent } from '@/lib/stripe-connect/charges'
+import {
+  getCurrentUser,
+  resolveTenantSlugOrId,
+  resolveTenantForConnect,
+} from '@/lib/stripe-connect/api-helpers'
+import { isStripeTestAccount } from '@/lib/stripe-connect/test-accounts'
+import { ensureStripeCustomerIdForAccount } from '@repo/bookings-payments'
+import {
+  resolveCourseForPurchase,
+  type CourseForPurchase,
+} from '@/lib/courses/resolve-course-for-purchase'
+
+export async function POST(request: NextRequest) {
+  const payload = await getPayload()
+  const user = await getCurrentUser(payload, request)
+  if (!user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const body = await request.json().catch(() => null)
+  if (!body || typeof body !== 'object') {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const metadata =
+    body.metadata && typeof body.metadata === 'object'
+      ? (body.metadata as Record<string, unknown>)
+      : null
+  const courseIdRaw = body.courseId ?? metadata?.courseId
+  const courseId =
+    typeof courseIdRaw === 'number'
+      ? courseIdRaw
+      : typeof courseIdRaw === 'string'
+        ? parseInt(courseIdRaw, 10)
+        : undefined
+  if (courseId == null || !Number.isFinite(courseId) || courseId < 1) {
+    return NextResponse.json(
+      { error: 'courseId required and must be a positive integer' },
+      { status: 400 },
+    )
+  }
+
+  const tenantSlugOrId = resolveTenantSlugOrId(request)
+  if (!tenantSlugOrId) {
+    return NextResponse.json(
+      { error: 'Tenant context required (x-tenant-slug / x-tenant-id / tenant-slug cookie)' },
+      { status: 400 },
+    )
+  }
+
+  const tenant = await resolveTenantForConnect(payload, String(tenantSlugOrId))
+  if (!tenant) {
+    return NextResponse.json({ error: 'Tenant not found' }, { status: 404 })
+  }
+
+  if (!tenant.stripeConnectAccountId || tenant.stripeConnectOnboardingStatus !== 'active') {
+    return NextResponse.json({ error: 'Tenant is not connected to Stripe' }, { status: 400 })
+  }
+
+  const course = (await payload
+    .findByID({
+      collection: 'courses' as import('payload').CollectionSlug,
+      id: courseId,
+      depth: 0,
+      overrideAccess: true,
+    })
+    .catch(() => null)) as CourseForPurchase | null
+
+  const activeCount = await payload.find({
+    collection: 'course-enrollments' as import('payload').CollectionSlug,
+    where: {
+      and: [
+        { course: { equals: courseId } },
+        { tenant: { equals: tenant.id } },
+        { status: { equals: 'active' } },
+      ],
+    },
+    limit: 0,
+    depth: 0,
+    overrideAccess: true,
+  })
+
+  const resolved = resolveCourseForPurchase({
+    course,
+    expectedTenantId: tenant.id,
+    activeEnrollmentCount: activeCount.totalDocs ?? 0,
+  })
+  if (!resolved.ok) {
+    return NextResponse.json({ error: resolved.error }, { status: resolved.status })
+  }
+
+  const placeholderAccount = /^acct_[a-z0-9_]+$/.test(
+    tenant.stripeConnectAccountId?.trim() ?? '',
+  )
+  if (isStripeTestAccount(tenant.stripeConnectAccountId) || placeholderAccount) {
+    const mockId = `pi_test_${Date.now()}`
+    return NextResponse.json({
+      clientSecret: `${mockId}_secret_test`,
+      stripeAccountId: tenant.stripeConnectAccountId,
+    })
+  }
+
+  try {
+    const userName = typeof user?.name === 'string' ? user.name : null
+    const { stripeCustomerId } = await ensureStripeCustomerIdForAccount({
+      payload,
+      userId: user.id,
+      email: user.email,
+      name: userName,
+      stripeAccountId: tenant.stripeConnectAccountId,
+    })
+
+    const { client_secret } = await createTenantPaymentIntent({
+      tenant: {
+        id: tenant.id,
+        stripeConnectAccountId: tenant.stripeConnectAccountId,
+        stripeConnectOnboardingStatus: tenant.stripeConnectOnboardingStatus,
+      },
+      classPriceAmount: resolved.priceCents,
+      currency: 'eur',
+      productType: 'course',
+      payload,
+      customerId: stripeCustomerId,
+      metadata: {
+        type: 'course_purchase',
+        userId: String(user.id),
+        tenantId: String(tenant.id),
+        courseId: String(courseId),
+      },
+    })
+    return NextResponse.json({
+      clientSecret: client_secret,
+      stripeAccountId: tenant.stripeConnectAccountId,
+    })
+  } catch (e) {
+    const message = e instanceof Error ? e.message : 'Payment intent failed'
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}

--- a/apps/atnd-me/src/app/api/events/guest-checkout/route.ts
+++ b/apps/atnd-me/src/app/api/events/guest-checkout/route.ts
@@ -93,6 +93,10 @@ export async function POST(request: NextRequest) {
   }
 
   const quantity = Math.max(1, parseInt(metadata?.quantity ?? '1', 10) || 1)
+  const checkoutSessionId =
+    typeof metadata?.checkoutSessionId === 'string' && metadata.checkoutSessionId.trim()
+      ? metadata.checkoutSessionId.trim()
+      : null
 
   const timeslot = (await payload.findByID({
     collection: ATND_ME_BOOKINGS_COLLECTION_SLUGS.timeslots,
@@ -228,16 +232,24 @@ export async function POST(request: NextRequest) {
 
   let hold: { holdId: number; quantity: number }
   try {
-    hold = await upsertCheckoutHold(payload, {
+    const upserted = await upsertCheckoutHold(payload, {
       timeslotId,
       userId: guest.userId,
       tenantId,
       quantity,
+      checkoutSessionId,
       holdCollection: CHECKOUT_HOLD_COLLECTION_SLUG,
       timeslotsSlug: ATND_ME_BOOKINGS_COLLECTION_SLUGS.timeslots,
       eventTypesSlug: ATND_ME_BOOKINGS_COLLECTION_SLUGS.eventTypes,
       bookingsSlug: ATND_ME_BOOKINGS_COLLECTION_SLUGS.bookings,
     })
+    if (upserted.abandoned) {
+      return NextResponse.json(
+        { error: 'Checkout was cancelled. Please start again.' },
+        { status: 409 },
+      )
+    }
+    hold = { holdId: upserted.holdId, quantity: upserted.quantity }
   } catch (e) {
     const message = e instanceof Error ? e.message : 'Unable to reserve places'
     return NextResponse.json({ error: message }, { status: 400 })

--- a/apps/atnd-me/src/app/api/events/guest-release-hold/route.ts
+++ b/apps/atnd-me/src/app/api/events/guest-release-hold/route.ts
@@ -17,7 +17,7 @@ function clientIp(request: NextRequest): string {
 
 /**
  * POST /api/events/guest-release-hold
- * Body: { timeslotId: number | string, guestEmail: string }
+ * Body: { timeslotId: number | string, guestEmail: string, checkoutSessionId?: string }
  *
  * Releases an active checkout hold for a guest (no browser session).
  * Used on page exit / refresh / abandoning Continue-to-payment.
@@ -56,6 +56,12 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'A valid email is required' }, { status: 400 })
   }
 
+  const checkoutSessionIdRaw = (body as { checkoutSessionId?: unknown }).checkoutSessionId
+  const checkoutSessionId =
+    typeof checkoutSessionIdRaw === 'string' && checkoutSessionIdRaw.trim()
+      ? checkoutSessionIdRaw.trim()
+      : null
+
   const ip = clientIp(request)
   const ipLimit = checkRateLimit({
     key: `guest-release-hold:ip:${ip}`,
@@ -85,6 +91,7 @@ export async function POST(request: NextRequest) {
     const result = await releaseCheckoutHold(payload, {
       timeslotId,
       userId: Number(user.id),
+      checkoutSessionId,
       holdCollection: CHECKOUT_HOLD_COLLECTION_SLUG,
     })
     return NextResponse.json(result)

--- a/apps/atnd-me/src/app/api/events/guest-reserve-hold/route.ts
+++ b/apps/atnd-me/src/app/api/events/guest-reserve-hold/route.ts
@@ -7,7 +7,11 @@ import {
   resolveTenantSlugOrId,
   resolveTenantForConnect,
 } from '@/lib/stripe-connect/api-helpers'
-import { upsertCheckoutHold, CHECKOUT_HOLD_COLLECTION_SLUG } from '@repo/bookings-payments'
+import {
+  upsertCheckoutHold,
+  computeCapacityBreakdownWithHolds,
+  CHECKOUT_HOLD_COLLECTION_SLUG,
+} from '@repo/bookings-payments'
 import { ATND_ME_BOOKINGS_COLLECTION_SLUGS } from '@/constants/bookings-collection-slugs'
 import { checkRateLimit } from '@/lib/onboarding/rateLimit'
 
@@ -153,7 +157,18 @@ export async function POST(request: NextRequest) {
         abandoned: true,
       })
     }
-    return NextResponse.json({ holdId: hold.holdId, quantity: hold.quantity })
+    const remaining = await computeCapacityBreakdownWithHolds(payload, timeslotId, {
+      timeslotsSlug: ATND_ME_BOOKINGS_COLLECTION_SLUGS.timeslots,
+      eventTypesSlug: ATND_ME_BOOKINGS_COLLECTION_SLUGS.eventTypes,
+      bookingsSlug: ATND_ME_BOOKINGS_COLLECTION_SLUGS.bookings,
+      holdCollection: CHECKOUT_HOLD_COLLECTION_SLUG,
+    })
+    return NextResponse.json({
+      holdId: hold.holdId,
+      quantity: hold.quantity,
+      remainingCapacity: remaining.remaining,
+      remainingConfirmedOnly: remaining.remainingConfirmedOnly,
+    })
   } catch (e) {
     const message = e instanceof Error ? e.message : 'Unable to reserve places'
     return NextResponse.json({ error: message }, { status: 400 })

--- a/apps/atnd-me/src/app/api/events/guest-reserve-hold/route.ts
+++ b/apps/atnd-me/src/app/api/events/guest-reserve-hold/route.ts
@@ -20,7 +20,7 @@ function clientIp(request: NextRequest): string {
 
 /**
  * POST /api/events/guest-reserve-hold
- * Body: { timeslotId, quantity?, guestName, guestEmail }
+ * Body: { timeslotId, quantity?, guestName, guestEmail, checkoutSessionId? }
  *
  * Reserves capacity as soon as the guest clicks Continue — before PaymentIntent
  * creation — so page-exit release has something to clear.
@@ -49,6 +49,11 @@ export async function POST(request: NextRequest) {
       ? (body as { guestEmail: string }).guestEmail
       : ''
   const guestEmail = guestEmailRaw.trim().toLowerCase()
+  const checkoutSessionIdRaw = (body as { checkoutSessionId?: unknown }).checkoutSessionId
+  const checkoutSessionId =
+    typeof checkoutSessionIdRaw === 'string' && checkoutSessionIdRaw.trim()
+      ? checkoutSessionIdRaw.trim()
+      : null
 
   if (!guestName || guestName.length < 2) {
     return NextResponse.json({ error: 'Name is required' }, { status: 400 })
@@ -135,11 +140,19 @@ export async function POST(request: NextRequest) {
       userId: guest.userId,
       tenantId,
       quantity,
+      checkoutSessionId,
       holdCollection: CHECKOUT_HOLD_COLLECTION_SLUG,
       timeslotsSlug: ATND_ME_BOOKINGS_COLLECTION_SLUGS.timeslots,
       eventTypesSlug: ATND_ME_BOOKINGS_COLLECTION_SLUGS.eventTypes,
       bookingsSlug: ATND_ME_BOOKINGS_COLLECTION_SLUGS.bookings,
     })
+    if (hold.abandoned) {
+      return NextResponse.json({
+        holdId: null,
+        quantity: 0,
+        abandoned: true,
+      })
+    }
     return NextResponse.json({ holdId: hold.holdId, quantity: hold.quantity })
   } catch (e) {
     const message = e instanceof Error ? e.message : 'Unable to reserve places'

--- a/apps/atnd-me/src/app/api/stripe/connect/create-checkout-session/route.ts
+++ b/apps/atnd-me/src/app/api/stripe/connect/create-checkout-session/route.ts
@@ -215,7 +215,8 @@ export async function POST(request: NextRequest) {
 
   if (
     mode === 'payment' &&
-    metadataFromBody?.type === 'class_pass_purchase' &&
+    (metadataFromBody?.type === 'class_pass_purchase' ||
+      metadataFromBody?.type === 'course_purchase') &&
     !isTestShortcut &&
     !isTestConnectAccount &&
     typeof tenant.id === 'number' &&
@@ -230,7 +231,8 @@ export async function POST(request: NextRequest) {
       bookingFeeAmount = await calculateBookingFeeAmount({
         payload,
         tenantId: tenant.id,
-        productType: 'class-pass',
+        productType:
+          metadataFromBody?.type === 'course_purchase' ? 'course' : 'class-pass',
         classPriceAmount,
       })
     }
@@ -263,7 +265,9 @@ export async function POST(request: NextRequest) {
           ? 'subscription'
           : mode === 'payment' && metadataFromBody?.type === 'class_pass_purchase'
             ? 'class-pass'
-            : undefined,
+            : mode === 'payment' && metadataFromBody?.type === 'course_purchase'
+              ? 'course'
+              : undefined,
       subscriptionApplicationFeePercent,
     })
 

--- a/apps/atnd-me/src/app/api/stripe/webhook/route.ts
+++ b/apps/atnd-me/src/app/api/stripe/webhook/route.ts
@@ -42,6 +42,7 @@ import { getStripeConnectOnboardingStatus } from '@/lib/stripe-connect/account-s
 import { findUserByCustomer } from '@repo/bookings-payments'
 import { handleSubscriptionGiftBalance } from '@/lib/stripe-connect/webhook/checkout-gift-credit'
 import { assignClassPassFromPurchase } from '@/lib/stripe-connect/webhook/assign-class-pass-from-purchase'
+import { assignCourseEnrollmentFromPurchase } from '@/lib/stripe-connect/webhook/assign-course-enrollment-from-purchase'
 import {
   extractStripePromotionCodeId,
   extractStripePromotionCodeIdFromLegacyDiscount,
@@ -160,6 +161,21 @@ export async function POST(request: NextRequest) {
           transactionId: paymentIntentId,
           tenantContext: paymentIntentTenantContext,
           stripePromotionCodeId,
+        })
+      }
+    }
+
+    // Course purchase (paid Checkout / PaymentIntent path)
+    if (tenant && meta.type === 'course_purchase') {
+      const paymentIntentId =
+        typeof obj?.id === 'string' && obj.id.trim() ? obj.id.trim() : null
+      if (paymentIntentId) {
+        await assignCourseEnrollmentFromPurchase({
+          payload,
+          tenantId: tenant.id,
+          metadata: meta,
+          transactionId: paymentIntentId,
+          tenantContext: paymentIntentTenantContext,
         })
       }
     }
@@ -341,6 +357,30 @@ export async function POST(request: NextRequest) {
       } else {
         payload.logger?.error?.(
           `checkout.session.completed: class_pass_purchase skipped (tenant=${tenant?.id ?? 'null'}, session=${sessionId ?? 'null'})`,
+        )
+      }
+    }
+
+    if (
+      obj?.mode === 'payment' &&
+      obj.payment_status === 'paid' &&
+      !hasPaymentIntent &&
+      meta.type === 'course_purchase'
+    ) {
+      const accountId = getAccountIdFromEvent(event)
+      const tenant = await resolveTenant(payload, accountId, meta.tenantId)
+      const sessionId = typeof obj.id === 'string' && obj.id.trim() ? obj.id.trim() : null
+      if (tenant && sessionId) {
+        await assignCourseEnrollmentFromPurchase({
+          payload,
+          tenantId: tenant.id,
+          metadata: meta,
+          transactionId: sessionId,
+          tenantContext: { tenant: tenant.id },
+        })
+      } else {
+        payload.logger?.error?.(
+          `checkout.session.completed: course_purchase skipped (tenant=${tenant?.id ?? 'null'}, session=${sessionId ?? 'null'})`,
         )
       }
     }

--- a/apps/atnd-me/src/blocks/EventCheckout/Component.tsx
+++ b/apps/atnd-me/src/blocks/EventCheckout/Component.tsx
@@ -42,6 +42,12 @@ export async function EventCheckoutBlock({
     typeof timeslot.eventType === 'object' ? (timeslot.eventType as EventType) : null
   const dropIn = resolveDropInFromEventType(eventType)
   const remaining = typeof timeslot.remainingCapacity === 'number' ? timeslot.remainingCapacity : 0
+  const remainingConfirmedOnly =
+    typeof timeslot.remainingConfirmedOnly === 'number'
+      ? timeslot.remainingConfirmedOnly
+      : remaining
+  const ownHoldQuantity =
+    typeof timeslot.ownHoldQuantity === 'number' ? timeslot.ownHoldQuantity : 0
   const endMs = Date.parse(timeslot.endTime)
   const isPast = Number.isFinite(endMs) ? endMs < Date.now() : false
   const user = await currentUser()
@@ -60,6 +66,8 @@ export async function EventCheckoutBlock({
           }
         }
         remainingCapacity={remaining}
+        remainingConfirmedOnly={remainingConfirmedOnly}
+        initialOwnHoldQuantity={ownHoldQuantity}
         isAuthenticated={Boolean(user?.id)}
         isPast={isPast}
         successUrl="/success"

--- a/apps/atnd-me/src/collections/CourseEmailDeliveries/index.ts
+++ b/apps/atnd-me/src/collections/CourseEmailDeliveries/index.ts
@@ -1,0 +1,103 @@
+import type { CollectionConfig } from 'payload'
+import { checkRole } from '@repo/shared-utils'
+import type { User as SharedUser } from '@repo/shared-types'
+import { COURSE_EMAIL_SEND_TIMING_OPTIONS } from '@/fields/courseEmailFields'
+
+export const COURSE_EMAIL_DELIVERIES_SLUG = 'course-email-deliveries' as const
+
+export const CourseEmailDeliveries: CollectionConfig = {
+  slug: COURSE_EMAIL_DELIVERIES_SLUG,
+  labels: {
+    singular: 'Course email delivery',
+    plural: 'Course email deliveries',
+  },
+  admin: {
+    group: 'Bookings',
+    useAsTitle: 'id',
+    defaultColumns: ['user', 'course', 'sendTiming', 'status', 'scheduledFor', 'sentAt'],
+    description: 'Tracks scheduled and sent course emails for idempotency.',
+    hidden: ({ user }) => !checkRole(['super-admin'], user as unknown as SharedUser | null),
+  },
+  access: {
+    read: ({ req: { user } }) => checkRole(['super-admin'], user as SharedUser | null),
+    create: () => false,
+    update: () => false,
+    delete: ({ req: { user } }) => checkRole(['super-admin'], user as SharedUser | null),
+  },
+  indexes: [
+    {
+      fields: ['tenant', 'user', 'enrollment', 'course', 'emailConfigId'],
+      unique: true,
+    },
+  ],
+  fields: [
+    {
+      name: 'user',
+      type: 'relationship',
+      relationTo: 'users',
+      required: true,
+      index: true,
+    },
+    {
+      name: 'enrollment',
+      type: 'relationship',
+      relationTo: 'course-enrollments' as import('payload').CollectionSlug,
+      required: true,
+      index: true,
+    },
+    {
+      name: 'course',
+      type: 'relationship',
+      relationTo: 'courses' as import('payload').CollectionSlug,
+      required: true,
+    },
+    {
+      name: 'emailConfigId',
+      type: 'text',
+      required: true,
+      admin: {
+        readOnly: true,
+        description: 'ID of the courseEmails array entry that triggered this delivery.',
+      },
+    },
+    {
+      name: 'sendTiming',
+      type: 'select',
+      required: true,
+      options: [...COURSE_EMAIL_SEND_TIMING_OPTIONS],
+    },
+    {
+      name: 'status',
+      type: 'select',
+      required: true,
+      defaultValue: 'scheduled',
+      options: [
+        { label: 'Scheduled', value: 'scheduled' },
+        { label: 'Sent', value: 'sent' },
+        { label: 'Cancelled', value: 'cancelled' },
+      ],
+    },
+    {
+      name: 'payloadJobId',
+      type: 'number',
+      admin: {
+        readOnly: true,
+        description: 'Payload job queued for scheduled delivery.',
+      },
+    },
+    {
+      name: 'scheduledFor',
+      type: 'date',
+      admin: {
+        date: { pickerAppearance: 'dayAndTime' },
+      },
+    },
+    {
+      name: 'sentAt',
+      type: 'date',
+      admin: {
+        date: { pickerAppearance: 'dayAndTime' },
+      },
+    },
+  ],
+}

--- a/apps/atnd-me/src/components/RichText/Client.tsx
+++ b/apps/atnd-me/src/components/RichText/Client.tsx
@@ -43,6 +43,9 @@ const internalDocToHref = ({ linkNode }: { linkNode: SerializedLinkNode }) => {
     throw new Error('Expected value to be an object')
   }
   const slug = value.slug
+  if (!slug || (relationTo !== 'pages' && relationTo !== 'posts')) {
+    return '#'
+  }
   return relationTo === 'posts' ? `/posts/${slug}` : `/${slug}`
 }
 

--- a/apps/atnd-me/src/components/courses/CourseDetailView.tsx
+++ b/apps/atnd-me/src/components/courses/CourseDetailView.tsx
@@ -1,0 +1,91 @@
+import { currentUser } from '@/lib/auth/context/get-context-props'
+import { CourseEnrollPanel } from '@/components/courses/CourseEnrollPanel'
+import { formatCourseAccessWindowCopy } from '@/lib/courses/format-course-access-window'
+
+export type CourseDetailDoc = {
+  id: number
+  title?: string | null
+  slug?: string | null
+  about?: string | null
+  status?: string | null
+  startDate?: string | null
+  endDate?: string | null
+  durationLength?: number | null
+  durationUnit?: 'days' | 'weeks' | null
+  maxEnrollments?: number | null
+  priceInformation?: { price?: number | null } | null
+}
+
+type CourseDetailViewProps = {
+  course: CourseDetailDoc
+  activeEnrollmentCount?: number
+}
+
+export async function CourseDetailView({
+  course,
+  activeEnrollmentCount = 0,
+}: CourseDetailViewProps) {
+  const user = await currentUser()
+  const isAuthenticated = Boolean(user?.id)
+  const title = course.title?.trim() || 'Course'
+  const price =
+    typeof course.priceInformation?.price === 'number' ? course.priceInformation.price : 0
+  const accessWindowLabel = formatCourseAccessWindowCopy(course)
+  const max =
+    typeof course.maxEnrollments === 'number' && course.maxEnrollments >= 1
+      ? course.maxEnrollments
+      : null
+  const remaining = max == null ? null : Math.max(0, max - activeEnrollmentCount)
+  const isOpen = course.status === 'open'
+
+  return (
+    <div className="pt-24 pb-8">
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_22rem] lg:gap-x-8 lg:gap-y-6 lg:items-start">
+        <header className="order-2 space-y-1.5 lg:col-start-1 lg:order-1">
+          {accessWindowLabel ? (
+            <p className="text-sm font-medium uppercase tracking-wide text-muted-foreground">
+              {accessWindowLabel}
+            </p>
+          ) : null}
+          <h1 className="max-w-3xl text-3xl font-bold tracking-tight text-foreground md:text-4xl">
+            {title}
+          </h1>
+          {remaining != null ? (
+            <p
+              className={`pt-1 text-sm lg:hidden ${
+                remaining > 0 && remaining <= 6
+                  ? 'font-medium text-amber-700 dark:text-amber-400'
+                  : 'text-muted-foreground'
+              }`}
+              data-testid="course-meta-places"
+            >
+              {remaining <= 0
+                ? 'Sold out'
+                : remaining === 1
+                  ? '1 place left'
+                  : `${remaining} places left`}
+            </p>
+          ) : null}
+        </header>
+
+        <div className="order-1 lg:order-2 lg:col-start-2 lg:row-span-2 lg:self-start lg:sticky lg:top-24">
+          <CourseEnrollPanel
+            courseId={course.id}
+            price={price}
+            remainingEnrollments={remaining}
+            isAuthenticated={isAuthenticated}
+            isOpen={isOpen}
+            accessWindowLabel={accessWindowLabel}
+            successUrl="/success"
+          />
+        </div>
+
+        {course.about?.trim() ? (
+          <section className="order-3 lg:col-start-1">
+            <p className="whitespace-pre-wrap text-muted-foreground">{course.about}</p>
+          </section>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/apps/atnd-me/src/components/courses/CourseDetailView.tsx
+++ b/apps/atnd-me/src/components/courses/CourseDetailView.tsx
@@ -1,12 +1,18 @@
+import Image from 'next/image'
+import type { DefaultTypedEditorState } from '@payloadcms/richtext-lexical'
 import { currentUser } from '@/lib/auth/context/get-context-props'
+import RichText from '@/components/RichText'
 import { CourseEnrollPanel } from '@/components/courses/CourseEnrollPanel'
 import { formatCourseAccessWindowCopy } from '@/lib/courses/format-course-access-window'
+import { mediaUrl } from '@/components/events/eventPageTypes'
+import type { Media } from '@/payload-types'
 
 export type CourseDetailDoc = {
   id: number
   title?: string | null
   slug?: string | null
-  about?: string | null
+  about?: DefaultTypedEditorState | null
+  coverImage?: (number | null) | Media
   status?: string | null
   startDate?: string | null
   endDate?: string | null
@@ -37,11 +43,30 @@ export async function CourseDetailView({
       : null
   const remaining = max == null ? null : Math.max(0, max - activeEnrollmentCount)
   const isOpen = course.status === 'open'
+  const cover =
+    course.coverImage && typeof course.coverImage === 'object'
+      ? (course.coverImage as Media)
+      : null
+  const coverUrl = mediaUrl(cover)
+  const about = course.about ?? null
 
   return (
     <div className="pt-24 pb-8">
       <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_22rem] lg:gap-x-8 lg:gap-y-6 lg:items-start">
-        <header className="order-2 space-y-1.5 lg:col-start-1 lg:order-1">
+        {coverUrl ? (
+          <div className="relative order-1 aspect-[21/9] w-full overflow-hidden rounded-xl md:aspect-[3/1] lg:col-span-2">
+            <Image
+              src={coverUrl}
+              alt={cover?.alt || title}
+              fill
+              sizes="(max-width: 1024px) 100vw, 1024px"
+              className="object-cover"
+              priority
+            />
+          </div>
+        ) : null}
+
+        <header className="order-2 space-y-1.5 lg:col-start-1">
           {accessWindowLabel ? (
             <p className="text-sm font-medium uppercase tracking-wide text-muted-foreground">
               {accessWindowLabel}
@@ -68,7 +93,7 @@ export async function CourseDetailView({
           ) : null}
         </header>
 
-        <div className="order-1 lg:order-2 lg:col-start-2 lg:row-span-2 lg:self-start lg:sticky lg:top-24">
+        <div className="order-3 lg:col-start-2 lg:row-span-2 lg:self-start lg:sticky lg:top-24">
           <CourseEnrollPanel
             courseId={course.id}
             price={price}
@@ -80,9 +105,9 @@ export async function CourseDetailView({
           />
         </div>
 
-        {course.about?.trim() ? (
-          <section className="order-3 lg:col-start-1">
-            <p className="whitespace-pre-wrap text-muted-foreground">{course.about}</p>
+        {about ? (
+          <section className="order-4 lg:col-start-1">
+            <RichText data={about} enableGutter={false} />
           </section>
         ) : null}
       </div>

--- a/apps/atnd-me/src/components/courses/CourseDetailView.tsx
+++ b/apps/atnd-me/src/components/courses/CourseDetailView.tsx
@@ -93,7 +93,7 @@ export async function CourseDetailView({
           ) : null}
         </header>
 
-        <div className="order-3 lg:col-start-2 lg:row-span-2 lg:self-start lg:sticky lg:top-24">
+        <div className="order-3 lg:col-start-2 lg:row-span-3 lg:self-start lg:sticky lg:top-24">
           <CourseEnrollPanel
             courseId={course.id}
             price={price}
@@ -106,9 +106,11 @@ export async function CourseDetailView({
         </div>
 
         {about ? (
-          <section className="order-4 lg:col-start-1">
-            <RichText data={about} enableGutter={false} />
-          </section>
+          <div className="order-4 space-y-6 lg:col-start-1">
+            <section>
+              <RichText data={about} enableGutter={false} />
+            </section>
+          </div>
         ) : null}
       </div>
     </div>

--- a/apps/atnd-me/src/components/courses/CourseEnrollPanel.tsx
+++ b/apps/atnd-me/src/components/courses/CourseEnrollPanel.tsx
@@ -1,0 +1,204 @@
+'use client'
+
+import React, { useState } from 'react'
+import { CheckoutForm } from '@repo/payments-next'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { isCompleteGuestEmail } from '@/lib/courses/resolve-course-for-purchase'
+
+type CourseEnrollPanelProps = {
+  courseId: number
+  price: number
+  remainingEnrollments: number | null
+  isAuthenticated: boolean
+  isOpen: boolean
+  accessWindowLabel: string | null
+  successUrl?: string
+}
+
+function placesLabel(remaining: number | null): string | null {
+  if (remaining == null) return null
+  if (remaining <= 0) return 'Sold out'
+  if (remaining === 1) return '1 place left'
+  return `${remaining} places left`
+}
+
+export function CourseEnrollPanel({
+  courseId,
+  price,
+  remainingEnrollments,
+  isAuthenticated,
+  isOpen,
+  accessWindowLabel,
+  successUrl = '/success',
+}: CourseEnrollPanelProps) {
+  const [guestName, setGuestName] = useState('')
+  const [guestEmail, setGuestEmail] = useState('')
+  const [settledGuest, setSettledGuest] = useState<{ name: string; email: string } | null>(null)
+  const [guestFormError, setGuestFormError] = useState<string | null>(null)
+
+  const soldOut = remainingEnrollments != null && remainingEnrollments <= 0
+  const places = placesLabel(remainingEnrollments)
+  const emphasizePlaces =
+    remainingEnrollments != null && remainingEnrollments > 0 && remainingEnrollments <= 6
+
+  if (!isOpen) {
+    return (
+      <aside
+        className="rounded-xl border border-border bg-card p-5 shadow-sm"
+        data-testid="course-enroll-panel"
+      >
+        <h2 className="text-lg font-semibold text-foreground">Enroll</h2>
+        <p className="mt-2 text-sm text-muted-foreground">Enrollment is closed for this course.</p>
+      </aside>
+    )
+  }
+
+  if (soldOut) {
+    return (
+      <aside
+        className="rounded-xl border border-border bg-card p-5 shadow-sm"
+        data-testid="course-enroll-panel"
+      >
+        <h2 className="text-lg font-semibold text-foreground">Enroll</h2>
+        <p className="mt-2 text-sm font-medium text-destructive">Sold out</p>
+      </aside>
+    )
+  }
+
+  if (price <= 0) {
+    return (
+      <aside
+        className="rounded-xl border border-border bg-card p-5 shadow-sm"
+        data-testid="course-enroll-panel"
+      >
+        <h2 className="text-lg font-semibold text-foreground">Enroll</h2>
+        <p className="mt-2 text-sm text-muted-foreground">Price is not configured for this course.</p>
+      </aside>
+    )
+  }
+
+  const handleContinueToPayment = (e: React.FormEvent) => {
+    e.preventDefault()
+    const name = guestName.trim()
+    const email = guestEmail.trim().toLowerCase()
+    if (name.length < 2) {
+      setGuestFormError('Enter your name to continue.')
+      return
+    }
+    if (!isCompleteGuestEmail(email)) {
+      setGuestFormError('Enter a complete email address (for example you@example.com).')
+      return
+    }
+    setGuestFormError(null)
+    setSettledGuest({ name, email })
+  }
+
+  const priceComponent = (
+    <div className="my-2 text-lg font-medium">Total: €{price.toFixed(2)}</div>
+  )
+
+  return (
+    <aside
+      className="rounded-xl border border-border bg-card p-5 shadow-sm"
+      data-testid="course-enroll-panel"
+    >
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="text-lg font-semibold text-foreground">Enroll</h2>
+        <p className="text-xl font-semibold tabular-nums text-foreground">€{price.toFixed(2)}</p>
+      </div>
+
+      {accessWindowLabel ? (
+        <p className="mt-2 text-sm text-muted-foreground" data-testid="course-access-window">
+          {accessWindowLabel}
+        </p>
+      ) : null}
+
+      {places ? (
+        <p
+          className={`mt-2 text-sm ${
+            emphasizePlaces
+              ? 'font-medium text-amber-700 dark:text-amber-400'
+              : 'text-muted-foreground'
+          }`}
+          data-testid="course-places-remaining"
+        >
+          {places}
+        </p>
+      ) : null}
+
+      {isAuthenticated ? (
+        <div className="mt-4">
+          <CheckoutForm
+            price={price}
+            priceComponent={priceComponent}
+            createPaymentIntentUrl="/api/courses/purchase"
+            returnUrl={successUrl}
+            metadata={{ courseId: String(courseId) }}
+          />
+        </div>
+      ) : (
+        <div className="mt-4 space-y-4">
+          <form className="space-y-3" onSubmit={handleContinueToPayment}>
+            <div className="space-y-1.5">
+              <Label htmlFor="course-guest-name">Name</Label>
+              <Input
+                id="course-guest-name"
+                value={guestName}
+                onChange={(e) => {
+                  setGuestName(e.target.value)
+                  if (settledGuest) setSettledGuest(null)
+                }}
+                autoComplete="name"
+                data-testid="course-guest-name"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="course-guest-email">Email</Label>
+              <Input
+                id="course-guest-email"
+                type="email"
+                value={guestEmail}
+                onChange={(e) => {
+                  setGuestEmail(e.target.value)
+                  if (settledGuest) setSettledGuest(null)
+                }}
+                autoComplete="email"
+                data-testid="course-guest-email"
+              />
+            </div>
+            {guestFormError ? (
+              <p className="text-sm text-destructive" role="alert">
+                {guestFormError}
+              </p>
+            ) : null}
+            {!settledGuest ? (
+              <Button type="submit" className="w-full" data-testid="course-guest-checkout-continue">
+                Continue to payment
+              </Button>
+            ) : null}
+          </form>
+
+          {settledGuest ? (
+            <CheckoutForm
+              price={price}
+              priceComponent={priceComponent}
+              createPaymentIntentUrl="/api/courses/guest-checkout"
+              returnUrl={successUrl}
+              metadata={{
+                courseId: String(courseId),
+                guestName: settledGuest.name,
+                guestEmail: settledGuest.email,
+              }}
+            />
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              Enter your details, then continue when your email is complete.
+            </p>
+          )}
+        </div>
+      )}
+    </aside>
+  )
+}

--- a/apps/atnd-me/src/components/events/EventAuthenticatedCheckout.client.tsx
+++ b/apps/atnd-me/src/components/events/EventAuthenticatedCheckout.client.tsx
@@ -114,6 +114,9 @@ export function EventAuthenticatedCheckout({
       onReserveCheckoutHold={onReserveCheckoutHold}
       onPaymentRedirectStart={() => {
         paymentRedirectInProgressRef.current = true
+        return () => {
+          paymentRedirectInProgressRef.current = false
+        }
       }}
     />
   )

--- a/apps/atnd-me/src/components/events/EventDetailView.tsx
+++ b/apps/atnd-me/src/components/events/EventDetailView.tsx
@@ -9,6 +9,10 @@ import { HostedBy } from '@/components/events/HostedBy'
 import { EventTicketPanel } from '@/components/events/EventTicketPanel'
 import { EventAuthenticatedCheckout } from '@/components/events/EventAuthenticatedCheckout.client'
 import {
+  eventPlacesAvailability,
+  eventPlacesLabel,
+} from '@/components/events/eventPlacesAvailability'
+import {
   type EventPageTimeslot,
   mediaUrl,
   locationAddress,
@@ -52,6 +56,12 @@ export async function EventDetailView({
   const loc = locationAddress(branch)
   const dropIn = resolveDropInFromEventType(eventType)
   const remaining = typeof timeslot.remainingCapacity === 'number' ? timeslot.remainingCapacity : 0
+  const remainingConfirmedOnly =
+    typeof timeslot.remainingConfirmedOnly === 'number'
+      ? timeslot.remainingConfirmedOnly
+      : remaining
+  const ownHoldQuantity =
+    typeof timeslot.ownHoldQuantity === 'number' ? timeslot.ownHoldQuantity : 0
 
   const endMs = Date.parse(timeslot.endTime)
   const isPast = Number.isFinite(endMs) ? endMs < Date.now() : false
@@ -94,14 +104,19 @@ export async function EventDetailView({
 
   const serializableTimeslot = JSON.parse(JSON.stringify(timeslot))
 
-  const placesLabel =
-    remaining <= 0
-      ? 'Sold out'
-      : remaining === 1
-        ? '1 place left'
-        : `${remaining} places left`
+  const availability = eventPlacesAvailability({
+    remainingCapacity: remaining,
+    remainingConfirmedOnly,
+    ownHoldQuantity,
+  })
+  const placesLabel = availability.soldOut
+    ? 'Sold out'
+    : availability.temporarilyUnavailable
+      ? 'Currently being reserved'
+      : eventPlacesLabel(availability.viewerRemaining)
 
-  const emphasizePlaces = remaining > 0 && remaining <= 6
+  const emphasizePlaces =
+    availability.viewerRemaining > 0 && availability.viewerRemaining <= 6
 
   return (
     <div className="pt-24 pb-8">
@@ -158,6 +173,8 @@ export async function EventDetailView({
               }
             }
             remainingCapacity={remaining}
+            remainingConfirmedOnly={remainingConfirmedOnly}
+            initialOwnHoldQuantity={ownHoldQuantity}
             isAuthenticated={isAuthenticated}
             isPast={isPast}
             successUrl="/success"

--- a/apps/atnd-me/src/components/events/EventDetailView.tsx
+++ b/apps/atnd-me/src/components/events/EventDetailView.tsx
@@ -8,10 +8,7 @@ import { MapBlock } from '@/blocks/Map/Component'
 import { HostedBy } from '@/components/events/HostedBy'
 import { EventTicketPanel } from '@/components/events/EventTicketPanel'
 import { EventAuthenticatedCheckout } from '@/components/events/EventAuthenticatedCheckout.client'
-import {
-  eventPlacesAvailability,
-  eventPlacesLabel,
-} from '@/components/events/eventPlacesAvailability'
+import { EventPlacesMetaLabel } from '@/components/events/EventPlacesMetaLabel.client'
 import {
   type EventPageTimeslot,
   mediaUrl,
@@ -104,20 +101,6 @@ export async function EventDetailView({
 
   const serializableTimeslot = JSON.parse(JSON.stringify(timeslot))
 
-  const availability = eventPlacesAvailability({
-    remainingCapacity: remaining,
-    remainingConfirmedOnly,
-    ownHoldQuantity,
-  })
-  const placesLabel = availability.soldOut
-    ? 'Sold out'
-    : availability.temporarilyUnavailable
-      ? 'Currently being reserved'
-      : eventPlacesLabel(availability.viewerRemaining)
-
-  const emphasizePlaces =
-    availability.viewerRemaining > 0 && availability.viewerRemaining <= 6
-
   return (
     <div className="pt-24 pb-8">
       <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_22rem] lg:gap-x-8 lg:gap-y-6 lg:items-start">
@@ -149,16 +132,16 @@ export async function EventDetailView({
             </div>
           )}
           {/* Mobile-only capacity cue; desktop keeps it in the ticket panel. */}
-          <p
-            className={`pt-1 text-sm lg:hidden ${
-              emphasizePlaces
-                ? 'font-medium text-amber-700 dark:text-amber-400'
-                : 'text-muted-foreground'
-            }`}
-            data-testid="event-meta-places"
-          >
-            {placesLabel}
-          </p>
+          <EventPlacesMetaLabel
+            timeslotId={timeslot.id}
+            remainingCapacity={remaining}
+            remainingConfirmedOnly={remainingConfirmedOnly}
+            initialOwnHoldQuantity={ownHoldQuantity}
+            isAuthenticated={isAuthenticated}
+            className="pt-1 text-sm lg:hidden"
+            emphasizeClassName="font-medium text-amber-700 dark:text-amber-400"
+            mutedClassName="text-muted-foreground"
+          />
         </header>
 
         <div className="order-3 lg:col-start-2 lg:row-span-3 lg:self-start lg:sticky lg:top-24">

--- a/apps/atnd-me/src/components/events/EventPlacesMetaLabel.client.tsx
+++ b/apps/atnd-me/src/components/events/EventPlacesMetaLabel.client.tsx
@@ -1,0 +1,79 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+
+import {
+  eventPlacesAvailability,
+  eventPlacesLabel,
+  guestCheckoutHoldStorageKey,
+} from '@/components/events/eventPlacesAvailability'
+
+type EventPlacesMetaLabelProps = {
+  timeslotId: number
+  remainingCapacity: number
+  remainingConfirmedOnly: number
+  initialOwnHoldQuantity: number
+  isAuthenticated: boolean
+  className?: string
+  emphasizeClassName?: string
+  mutedClassName?: string
+}
+
+/**
+ * Mobile hero capacity label. Guests have no auth session, so SSR cannot resolve their
+ * hold — read sessionStorage so a reload still adds the viewer's own hold back.
+ */
+export function EventPlacesMetaLabel({
+  timeslotId,
+  remainingCapacity,
+  remainingConfirmedOnly,
+  initialOwnHoldQuantity,
+  isAuthenticated,
+  className,
+  emphasizeClassName,
+  mutedClassName,
+}: EventPlacesMetaLabelProps) {
+  const [guestOwnHold] = useState(() => {
+    if (isAuthenticated || typeof sessionStorage === 'undefined') return 0
+    try {
+      const raw = sessionStorage.getItem(guestCheckoutHoldStorageKey(timeslotId))
+      if (!raw) return 0
+      const parsed = JSON.parse(raw) as { ownHoldQuantity?: unknown }
+      const qty = Math.max(0, Number(parsed.ownHoldQuantity) || 0)
+      if (qty <= 0) return 0
+      const heldByAnyone = Math.max(0, remainingConfirmedOnly - remainingCapacity)
+      return heldByAnyone >= qty ? qty : 0
+    } catch {
+      return 0
+    }
+  })
+
+  const ownHoldQuantity = Math.max(0, initialOwnHoldQuantity, guestOwnHold)
+  const availability = useMemo(
+    () =>
+      eventPlacesAvailability({
+        remainingCapacity,
+        remainingConfirmedOnly,
+        ownHoldQuantity,
+      }),
+    [remainingCapacity, remainingConfirmedOnly, ownHoldQuantity],
+  )
+
+  const label = availability.soldOut
+    ? 'Sold out'
+    : availability.temporarilyUnavailable
+      ? 'Currently being reserved'
+      : eventPlacesLabel(availability.viewerRemaining)
+
+  const emphasize =
+    availability.viewerRemaining > 0 && availability.viewerRemaining <= 6
+
+  return (
+    <p
+      className={`${className ?? ''} ${emphasize ? emphasizeClassName : mutedClassName}`}
+      data-testid="event-meta-places"
+    >
+      {label}
+    </p>
+  )
+}

--- a/apps/atnd-me/src/components/events/EventTicketPanel.tsx
+++ b/apps/atnd-me/src/components/events/EventTicketPanel.tsx
@@ -10,6 +10,12 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { calculateQuantityDiscount } from '@repo/shared-utils'
 import { releaseGuestCheckoutHold } from '@/lib/booking/releaseGuestCheckoutHold'
+import {
+  eventPlacesAvailability,
+  eventPlacesLabel,
+  guestCheckoutHoldStorageKey,
+  type StoredGuestCheckout,
+} from '@/components/events/eventPlacesAvailability'
 
 type DropInLike = {
   price?: number | null
@@ -21,6 +27,10 @@ type EventTicketPanelProps = {
   timeslot: Timeslot
   dropIn: DropInLike
   remainingCapacity: number
+  /** places − confirmed; hard sold-out when <= 0. Defaults to remainingCapacity. */
+  remainingConfirmedOnly?: number
+  /** Server-known hold for authenticated viewers. */
+  initialOwnHoldQuantity?: number
   isAuthenticated: boolean
   isPast: boolean
   successUrl?: string
@@ -36,12 +46,6 @@ function isCompleteGuestEmail(email: string): boolean {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim())
 }
 
-function placesLabel(remaining: number): string {
-  if (remaining <= 0) return 'Sold out'
-  if (remaining === 1) return '1 place left'
-  return `${remaining} places left`
-}
-
 function newCheckoutSessionId(): string {
   if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
     return crypto.randomUUID()
@@ -49,27 +53,61 @@ function newCheckoutSessionId(): string {
   return `guest-${Date.now()}-${Math.random().toString(36).slice(2)}`
 }
 
+function readStoredGuestCheckout(timeslotId: number): StoredGuestCheckout | null {
+  if (typeof sessionStorage === 'undefined') return null
+  try {
+    const raw = sessionStorage.getItem(guestCheckoutHoldStorageKey(timeslotId))
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as Partial<StoredGuestCheckout>
+    if (
+      typeof parsed.name !== 'string' ||
+      typeof parsed.email !== 'string' ||
+      !isCompleteGuestEmail(parsed.email)
+    ) {
+      return null
+    }
+    return {
+      name: parsed.name.trim(),
+      email: parsed.email.trim().toLowerCase(),
+      quantity: Math.max(1, Number(parsed.quantity) || 1),
+      ownHoldQuantity: Math.max(0, Number(parsed.ownHoldQuantity) || 0),
+    }
+  } catch {
+    return null
+  }
+}
+
+function writeStoredGuestCheckout(timeslotId: number, value: StoredGuestCheckout | null) {
+  if (typeof sessionStorage === 'undefined') return
+  const key = guestCheckoutHoldStorageKey(timeslotId)
+  if (!value) {
+    sessionStorage.removeItem(key)
+    return
+  }
+  sessionStorage.setItem(key, JSON.stringify(value))
+}
+
 export function EventTicketPanel({
   timeslot,
   dropIn,
   remainingCapacity,
+  remainingConfirmedOnly: remainingConfirmedOnlyProp,
+  initialOwnHoldQuantity = 0,
   isAuthenticated,
   isPast,
   successUrl = '/success',
   AuthenticatedCheckout,
 }: EventTicketPanelProps) {
+  const remainingConfirmedOnly =
+    typeof remainingConfirmedOnlyProp === 'number'
+      ? remainingConfirmedOnlyProp
+      : remainingCapacity
+
   const unitPrice = typeof dropIn.price === 'number' ? dropIn.price : 0
   const maxFromDropIn =
     dropIn.maxBookingsPerTimeslot == null
       ? Infinity
       : Math.max(1, Number(dropIn.maxBookingsPerTimeslot) || 1)
-  const maxQuantity = Math.max(
-    1,
-    Math.min(
-      Math.max(0, remainingCapacity),
-      maxFromDropIn === Infinity ? remainingCapacity : maxFromDropIn,
-    ),
-  )
 
   const [quantity, setQuantity] = useState(1)
   const [guestName, setGuestName] = useState('')
@@ -83,6 +121,12 @@ export function EventTicketPanel({
     email: string
     checkoutSessionId: string
   } | null>(null)
+  const [ownHoldQuantity, setOwnHoldQuantity] = useState(() => {
+    const fromServer = Math.max(0, initialOwnHoldQuantity)
+    if (fromServer > 0 || isAuthenticated) return fromServer
+    // Sync read avoids a "temporarily unavailable" flash before the restore effect.
+    return readStoredGuestCheckout(timeslot.id)?.ownHoldQuantity ?? 0
+  })
   const [guestFormError, setGuestFormError] = useState<string | null>(null)
   const [isReserving, setIsReserving] = useState(false)
   const [feeBreakdown, setFeeBreakdown] = useState<{
@@ -93,10 +137,111 @@ export function EventTicketPanel({
   const paymentRedirectInProgressRef = useRef(false)
   /** Bumped on exit so in-flight reserve upserts after leave are rolled back client-side. */
   const checkoutAttemptRef = useRef(0)
+  const didRestoreRef = useRef(false)
+
+  const availability = eventPlacesAvailability({
+    remainingCapacity,
+    remainingConfirmedOnly,
+    ownHoldQuantity,
+  })
+  const viewerRemaining = availability.viewerRemaining
+
+  const maxQuantity = Math.max(
+    1,
+    Math.min(
+      Math.max(viewerRemaining, ownHoldQuantity, 1),
+      maxFromDropIn === Infinity
+        ? Math.max(viewerRemaining, ownHoldQuantity, 1)
+        : maxFromDropIn,
+    ),
+  )
+
+  useEffect(() => {
+    setOwnHoldQuantity((prev) => Math.max(prev, Math.max(0, initialOwnHoldQuantity)))
+  }, [initialOwnHoldQuantity])
 
   useEffect(() => {
     if (quantity > maxQuantity) setQuantity(Math.max(1, maxQuantity))
   }, [maxQuantity, quantity])
+
+  // Restore mid-checkout guest after reload. pagehide releases the prior session's hold;
+  // re-reserve with a fresh checkoutSessionId so the released tombstone cannot block us.
+  useEffect(() => {
+    if (isAuthenticated || didRestoreRef.current) return
+    didRestoreRef.current = true
+    const saved = readStoredGuestCheckout(timeslot.id)
+    if (!saved || saved.ownHoldQuantity <= 0) return
+
+    const checkoutSessionId = newCheckoutSessionId()
+    setGuestName(saved.name)
+    setGuestEmail(saved.email)
+    setQuantity(saved.quantity)
+    setOwnHoldQuantity(saved.ownHoldQuantity)
+    setSettledGuest({
+      name: saved.name,
+      email: saved.email,
+      checkoutSessionId,
+    })
+    setIsReserving(true)
+
+    const attempt = checkoutAttemptRef.current
+    void (async () => {
+      try {
+        const res = await fetch('/api/events/guest-reserve-hold', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            timeslotId: timeslot.id,
+            quantity: saved.quantity,
+            guestName: saved.name,
+            guestEmail: saved.email,
+            checkoutSessionId,
+          }),
+        })
+        const data = (await res.json().catch(() => null)) as
+          | { error?: string; abandoned?: boolean }
+          | null
+        if (attempt !== checkoutAttemptRef.current) return
+        if (!res.ok || data?.abandoned) {
+          setSettledGuest(null)
+          setOwnHoldQuantity(0)
+          writeStoredGuestCheckout(timeslot.id, null)
+          setGuestFormError(
+            data?.error ||
+              'Your previous reservation expired. Enter your details to try again.',
+          )
+          return
+        }
+        setOwnHoldQuantity(saved.quantity)
+        writeStoredGuestCheckout(timeslot.id, {
+          name: saved.name,
+          email: saved.email,
+          quantity: saved.quantity,
+          ownHoldQuantity: saved.quantity,
+        })
+      } catch {
+        if (attempt !== checkoutAttemptRef.current) return
+        setSettledGuest(null)
+        setOwnHoldQuantity(0)
+        writeStoredGuestCheckout(timeslot.id, null)
+      } finally {
+        if (attempt === checkoutAttemptRef.current) setIsReserving(false)
+      }
+    })()
+  }, [isAuthenticated, timeslot.id])
+
+  useEffect(() => {
+    if (!settledGuest || ownHoldQuantity <= 0) {
+      if (!settledGuest) writeStoredGuestCheckout(timeslot.id, null)
+      return
+    }
+    writeStoredGuestCheckout(timeslot.id, {
+      name: settledGuest.name,
+      email: settledGuest.email,
+      quantity,
+      ownHoldQuantity,
+    })
+  }, [settledGuest, ownHoldQuantity, quantity, timeslot.id])
 
   // Release guest hold on refresh / tab close / navigate away / abandoning Continue.
   // Unload must use sync transport — see releaseGuestCheckoutHold + unit tests.
@@ -165,8 +310,11 @@ export function EventTicketPanel({
           checkoutSessionId: settledGuest.checkoutSessionId,
           sync: false,
         })
+        setOwnHoldQuantity(0)
+        writeStoredGuestCheckout(timeslot.id, null)
         return
       }
+      setOwnHoldQuantity(qty)
       return data?.holdId != null ? { holdId: String(data.holdId) } : undefined
     },
     [settledGuest, timeslot.id, quantity],
@@ -185,7 +333,7 @@ export function EventTicketPanel({
   const classPriceCents = Math.round(classPrice * 100)
 
   useEffect(() => {
-    if (isPast || remainingCapacity <= 0 || unitPrice <= 0) {
+    if (isPast || availability.soldOut || availability.temporarilyUnavailable || unitPrice <= 0) {
       setFeeBreakdown(null)
       return
     }
@@ -213,7 +361,14 @@ export function EventTicketPanel({
       controller.abort()
       clearTimeout(timer)
     }
-  }, [classPriceCents, isPast, remainingCapacity, timeslot.id, unitPrice])
+  }, [
+    classPriceCents,
+    isPast,
+    availability.soldOut,
+    availability.temporarilyUnavailable,
+    timeslot.id,
+    unitPrice,
+  ])
 
   const canContinue =
     guestName.trim().length >= 2 && isCompleteGuestEmail(guestEmail.trim())
@@ -222,7 +377,11 @@ export function EventTicketPanel({
     if (field === 'name') setGuestName(value)
     else setGuestEmail(value)
     // Editing after Continue must re-confirm so progressive TLDs never create users.
-    if (settledGuest) setSettledGuest(null)
+    if (settledGuest) {
+      setSettledGuest(null)
+      setOwnHoldQuantity(0)
+      writeStoredGuestCheckout(timeslot.id, null)
+    }
     if (guestFormError) setGuestFormError(null)
   }
 
@@ -261,11 +420,22 @@ export function EventTicketPanel({
         | null
       if (!res.ok || data?.abandoned) {
         setSettledGuest(null)
+        setOwnHoldQuantity(0)
+        writeStoredGuestCheckout(timeslot.id, null)
         setGuestFormError(data?.error || 'Unable to reserve places. Please try again.')
         return
       }
+      setOwnHoldQuantity(quantity)
+      writeStoredGuestCheckout(timeslot.id, {
+        name,
+        email,
+        quantity,
+        ownHoldQuantity: quantity,
+      })
     } catch {
       setSettledGuest(null)
+      setOwnHoldQuantity(0)
+      writeStoredGuestCheckout(timeslot.id, null)
       setGuestFormError('Unable to reserve places. Please try again.')
       return
     } finally {
@@ -273,8 +443,7 @@ export function EventTicketPanel({
     }
   }
 
-  const soldOut = remainingCapacity <= 0
-  const emphasizeRemaining = remainingCapacity > 0 && remainingCapacity <= 6
+  const emphasizeRemaining = viewerRemaining > 0 && viewerRemaining <= 6
 
   if (isPast) {
     return (
@@ -288,7 +457,7 @@ export function EventTicketPanel({
     )
   }
 
-  if (soldOut) {
+  if (availability.soldOut) {
     return (
       <aside
         className="rounded-xl border border-border bg-card p-5 shadow-sm"
@@ -296,6 +465,20 @@ export function EventTicketPanel({
       >
         <h2 className="text-lg font-semibold text-foreground">Get tickets</h2>
         <p className="mt-2 text-sm font-medium text-destructive">Sold out</p>
+      </aside>
+    )
+  }
+
+  if (availability.temporarilyUnavailable) {
+    return (
+      <aside
+        className="rounded-xl border border-border bg-card p-5 shadow-sm"
+        data-testid="event-ticket-panel"
+      >
+        <h2 className="text-lg font-semibold text-foreground">Get tickets</h2>
+        <p className="mt-2 text-sm font-medium text-amber-700 dark:text-amber-400">
+          All places are currently being reserved. Please try again in a few minutes.
+        </p>
       </aside>
     )
   }
@@ -331,7 +514,7 @@ export function EventTicketPanel({
         className={`mt-2 text-sm ${emphasizeRemaining ? 'font-medium text-amber-700 dark:text-amber-400' : 'text-muted-foreground'}`}
         data-testid="event-places-remaining"
       >
-        {placesLabel(remainingCapacity)}
+        {eventPlacesLabel(viewerRemaining)}
       </p>
 
       <div className="mt-4">
@@ -416,6 +599,7 @@ export function EventTicketPanel({
               onReserveCheckoutHold={reserveGuestHold}
               onPaymentRedirectStart={() => {
                 paymentRedirectInProgressRef.current = true
+                writeStoredGuestCheckout(timeslot.id, null)
                 return () => {
                   paymentRedirectInProgressRef.current = false
                 }

--- a/apps/atnd-me/src/components/events/EventTicketPanel.tsx
+++ b/apps/atnd-me/src/components/events/EventTicketPanel.tsx
@@ -42,6 +42,13 @@ function placesLabel(remaining: number): string {
   return `${remaining} places left`
 }
 
+function newCheckoutSessionId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+  return `guest-${Date.now()}-${Math.random().toString(36).slice(2)}`
+}
+
 export function EventTicketPanel({
   timeslot,
   dropIn,
@@ -71,7 +78,11 @@ export function EventTicketPanel({
    * Locked identity after Continue. CheckoutForm / guest get-or-create only run for these
    * values — not while typing `sam@execbjj.c` → `.co` → `.com`.
    */
-  const [settledGuest, setSettledGuest] = useState<{ name: string; email: string } | null>(null)
+  const [settledGuest, setSettledGuest] = useState<{
+    name: string
+    email: string
+    checkoutSessionId: string
+  } | null>(null)
   const [guestFormError, setGuestFormError] = useState<string | null>(null)
   const [isReserving, setIsReserving] = useState(false)
   const [feeBreakdown, setFeeBreakdown] = useState<{
@@ -80,6 +91,8 @@ export function EventTicketPanel({
     totalCents: number
   } | null>(null)
   const paymentRedirectInProgressRef = useRef(false)
+  /** Bumped on exit so in-flight reserve upserts after leave are rolled back client-side. */
+  const checkoutAttemptRef = useRef(0)
 
   useEffect(() => {
     if (quantity > maxQuantity) setQuantity(Math.max(1, maxQuantity))
@@ -92,22 +105,28 @@ export function EventTicketPanel({
 
     const timeslotId = timeslot.id
     const guestEmail = settledGuest.email
+    const checkoutSessionId = settledGuest.checkoutSessionId
 
     const releaseViaApi = (sync = false) => {
       releaseGuestCheckoutHold({
         timeslotId,
         guestEmail,
+        checkoutSessionId,
         sync,
         skip: paymentRedirectInProgressRef.current,
       })
     }
 
-    const handlePageExit = () => releaseViaApi(true)
+    const handlePageExit = () => {
+      checkoutAttemptRef.current += 1
+      releaseViaApi(true)
+    }
 
     window.addEventListener('pagehide', handlePageExit)
     window.addEventListener('beforeunload', handlePageExit)
 
     return () => {
+      checkoutAttemptRef.current += 1
       window.removeEventListener('pagehide', handlePageExit)
       window.removeEventListener('beforeunload', handlePageExit)
       releaseViaApi(false)
@@ -120,6 +139,7 @@ export function EventTicketPanel({
   const reserveGuestHold = useCallback(
     async (metadata: Record<string, string>) => {
       if (!settledGuest) return
+      const attempt = checkoutAttemptRef.current
       const qty = Math.max(1, parseInt(metadata.quantity ?? String(quantity), 10) || quantity)
       const res = await fetch('/api/events/guest-reserve-hold', {
         method: 'POST',
@@ -129,13 +149,23 @@ export function EventTicketPanel({
           quantity: qty,
           guestName: settledGuest.name,
           guestEmail: settledGuest.email,
+          checkoutSessionId: settledGuest.checkoutSessionId,
         }),
       })
       const data = (await res.json().catch(() => null)) as
-        | { holdId?: number; error?: string }
+        | { holdId?: number | null; abandoned?: boolean; error?: string }
         | null
       if (!res.ok) {
         throw new Error(data?.error || 'Unable to reserve places')
+      }
+      if (data?.abandoned || attempt !== checkoutAttemptRef.current) {
+        releaseGuestCheckoutHold({
+          timeslotId: timeslot.id,
+          guestEmail: settledGuest.email,
+          checkoutSessionId: settledGuest.checkoutSessionId,
+          sync: false,
+        })
+        return
       }
       return data?.holdId != null ? { holdId: String(data.holdId) } : undefined
     },
@@ -209,10 +239,11 @@ export function EventTicketPanel({
       return
     }
     setGuestFormError(null)
+    const checkoutSessionId = newCheckoutSessionId()
+    // Settle first so page-exit listeners are attached before/while the reserve runs.
+    setSettledGuest({ name, email, checkoutSessionId })
     setIsReserving(true)
 
-    // Reserve before mounting CheckoutForm so exit-release has a hold, and so we don't
-    // race a second create when onReserveCheckoutHold runs.
     try {
       const res = await fetch('/api/events/guest-reserve-hold', {
         method: 'POST',
@@ -222,21 +253,24 @@ export function EventTicketPanel({
           quantity,
           guestName: name,
           guestEmail: email,
+          checkoutSessionId,
         }),
       })
-      const data = (await res.json().catch(() => null)) as { error?: string } | null
-      if (!res.ok) {
+      const data = (await res.json().catch(() => null)) as
+        | { error?: string; abandoned?: boolean }
+        | null
+      if (!res.ok || data?.abandoned) {
+        setSettledGuest(null)
         setGuestFormError(data?.error || 'Unable to reserve places. Please try again.')
         return
       }
     } catch {
+      setSettledGuest(null)
       setGuestFormError('Unable to reserve places. Please try again.')
       return
     } finally {
       setIsReserving(false)
     }
-
-    setSettledGuest({ name, email })
   }
 
   const soldOut = remainingCapacity <= 0
@@ -382,12 +416,16 @@ export function EventTicketPanel({
               onReserveCheckoutHold={reserveGuestHold}
               onPaymentRedirectStart={() => {
                 paymentRedirectInProgressRef.current = true
+                return () => {
+                  paymentRedirectInProgressRef.current = false
+                }
               }}
               metadata={{
                 timeslotId: String(timeslot.id),
                 quantity: String(quantity),
                 guestName: settledGuest.name,
                 guestEmail: settledGuest.email,
+                checkoutSessionId: settledGuest.checkoutSessionId,
               }}
             />
           ) : (

--- a/apps/atnd-me/src/components/events/EventTicketPanel.tsx
+++ b/apps/atnd-me/src/components/events/EventTicketPanel.tsx
@@ -124,9 +124,16 @@ export function EventTicketPanel({
   const [ownHoldQuantity, setOwnHoldQuantity] = useState(() => {
     const fromServer = Math.max(0, initialOwnHoldQuantity)
     if (fromServer > 0 || isAuthenticated) return fromServer
-    // Sync read avoids a "temporarily unavailable" flash before the restore effect.
-    return readStoredGuestCheckout(timeslot.id)?.ownHoldQuantity ?? 0
+    const saved = readStoredGuestCheckout(timeslot.id)
+    if (!saved || saved.ownHoldQuantity <= 0) return 0
+    // Only count a stored guest hold when SSR remaining already looks like it includes
+    // someone's hold. If pagehide released before SSR, remaining === confirmed-only and
+    // adding the stored qty would inflate the label until re-reserve returns.
+    const heldByAnyone = Math.max(0, remainingConfirmedOnly - remainingCapacity)
+    return heldByAnyone >= saved.ownHoldQuantity ? saved.ownHoldQuantity : 0
   })
+  /** Global free spots (everyone's holds subtracted). Synced from SSR + reserve responses. */
+  const [globalRemaining, setGlobalRemaining] = useState(() => Math.max(0, remainingCapacity))
   const [guestFormError, setGuestFormError] = useState<string | null>(null)
   const [isReserving, setIsReserving] = useState(false)
   const [feeBreakdown, setFeeBreakdown] = useState<{
@@ -138,9 +145,16 @@ export function EventTicketPanel({
   /** Bumped on exit so in-flight reserve upserts after leave are rolled back client-side. */
   const checkoutAttemptRef = useRef(0)
   const didRestoreRef = useRef(false)
+  /** Shares one in-flight reserve across Continue, restore, and CheckoutForm. */
+  const reserveInFlightRef = useRef<Promise<void> | null>(null)
+  const lastReservedQtyRef = useRef(0)
+
+  useEffect(() => {
+    setGlobalRemaining(Math.max(0, remainingCapacity))
+  }, [remainingCapacity])
 
   const availability = eventPlacesAvailability({
-    remainingCapacity,
+    remainingCapacity: globalRemaining,
     remainingConfirmedOnly,
     ownHoldQuantity,
   })
@@ -164,8 +178,95 @@ export function EventTicketPanel({
     if (quantity > maxQuantity) setQuantity(Math.max(1, maxQuantity))
   }, [maxQuantity, quantity])
 
+  const applyReserveSuccess = useCallback(
+    (qty: number, remainingFromApi?: number) => {
+      setOwnHoldQuantity(qty)
+      lastReservedQtyRef.current = qty
+      if (typeof remainingFromApi === 'number' && Number.isFinite(remainingFromApi)) {
+        setGlobalRemaining(Math.max(0, remainingFromApi))
+      }
+    },
+    [],
+  )
+
+  const postGuestReserve = useCallback(
+    async (opts: {
+      name: string
+      email: string
+      checkoutSessionId: string
+      quantity: number
+    }): Promise<{
+      holdId?: string
+      abandoned?: boolean
+      error?: string
+      remainingCapacity?: number
+    }> => {
+      const previous = reserveInFlightRef.current
+      let releaseInFlight!: () => void
+      const gate = new Promise<void>((resolve) => {
+        releaseInFlight = resolve
+      })
+      reserveInFlightRef.current = gate
+
+      try {
+        if (previous) await previous.catch(() => undefined)
+
+        const res = await fetch('/api/events/guest-reserve-hold', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            timeslotId: timeslot.id,
+            quantity: opts.quantity,
+            guestName: opts.name,
+            guestEmail: opts.email,
+            checkoutSessionId: opts.checkoutSessionId,
+          }),
+        })
+        const data = (await res.json().catch(() => null)) as
+          | {
+              holdId?: number | null
+              abandoned?: boolean
+              error?: string
+              remainingCapacity?: number
+              quantity?: number
+            }
+          | null
+        if (!res.ok) {
+          return { error: data?.error || 'Unable to reserve places' }
+        }
+        if (data?.abandoned) {
+          return { abandoned: true, error: data.error }
+        }
+        const qty = Math.max(1, Number(data?.quantity) || opts.quantity)
+        applyReserveSuccess(
+          qty,
+          typeof data?.remainingCapacity === 'number' ? data.remainingCapacity : undefined,
+        )
+        writeStoredGuestCheckout(timeslot.id, {
+          name: opts.name,
+          email: opts.email,
+          quantity: qty,
+          ownHoldQuantity: qty,
+        })
+        return {
+          holdId: data?.holdId != null ? String(data.holdId) : undefined,
+          remainingCapacity:
+            typeof data?.remainingCapacity === 'number' ? data.remainingCapacity : undefined,
+        }
+      } finally {
+        releaseInFlight()
+        if (reserveInFlightRef.current === gate) {
+          reserveInFlightRef.current = null
+        }
+      }
+    },
+    [applyReserveSuccess, timeslot.id],
+  )
+
   // Restore mid-checkout guest after reload. pagehide releases the prior session's hold;
   // re-reserve with a fresh checkoutSessionId so the released tombstone cannot block us.
+  // CheckoutForm also reserves on mount — both paths share postGuestReserve's mutex so we
+  // never double-create active holds for the same guest.
   useEffect(() => {
     if (isAuthenticated || didRestoreRef.current) return
     didRestoreRef.current = true
@@ -176,7 +277,11 @@ export function EventTicketPanel({
     setGuestName(saved.name)
     setGuestEmail(saved.email)
     setQuantity(saved.quantity)
-    setOwnHoldQuantity(saved.ownHoldQuantity)
+    const heldByAnyone = Math.max(0, remainingConfirmedOnly - remainingCapacity)
+    if (heldByAnyone >= saved.ownHoldQuantity) {
+      // Soft-sold-out / own hold still in SSR remaining — keep checkout open during restore.
+      setOwnHoldQuantity(saved.ownHoldQuantity)
+    }
     setSettledGuest({
       name: saved.name,
       email: saved.email,
@@ -187,48 +292,34 @@ export function EventTicketPanel({
     const attempt = checkoutAttemptRef.current
     void (async () => {
       try {
-        const res = await fetch('/api/events/guest-reserve-hold', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            timeslotId: timeslot.id,
-            quantity: saved.quantity,
-            guestName: saved.name,
-            guestEmail: saved.email,
-            checkoutSessionId,
-          }),
-        })
-        const data = (await res.json().catch(() => null)) as
-          | { error?: string; abandoned?: boolean }
-          | null
-        if (attempt !== checkoutAttemptRef.current) return
-        if (!res.ok || data?.abandoned) {
-          setSettledGuest(null)
-          setOwnHoldQuantity(0)
-          writeStoredGuestCheckout(timeslot.id, null)
-          setGuestFormError(
-            data?.error ||
-              'Your previous reservation expired. Enter your details to try again.',
-          )
-          return
-        }
-        setOwnHoldQuantity(saved.quantity)
-        writeStoredGuestCheckout(timeslot.id, {
+        const result = await postGuestReserve({
           name: saved.name,
           email: saved.email,
+          checkoutSessionId,
           quantity: saved.quantity,
-          ownHoldQuantity: saved.quantity,
         })
+        if (attempt !== checkoutAttemptRef.current) return
+        if (result.error || result.abandoned) {
+          setSettledGuest(null)
+          setOwnHoldQuantity(0)
+          lastReservedQtyRef.current = 0
+          writeStoredGuestCheckout(timeslot.id, null)
+          setGuestFormError(
+            result.error ||
+              'Your previous reservation expired. Enter your details to try again.',
+          )
+        }
       } catch {
         if (attempt !== checkoutAttemptRef.current) return
         setSettledGuest(null)
         setOwnHoldQuantity(0)
+        lastReservedQtyRef.current = 0
         writeStoredGuestCheckout(timeslot.id, null)
       } finally {
         if (attempt === checkoutAttemptRef.current) setIsReserving(false)
       }
     })()
-  }, [isAuthenticated, timeslot.id])
+  }, [isAuthenticated, timeslot.id, postGuestReserve, remainingCapacity, remainingConfirmedOnly])
 
   useEffect(() => {
     if (!settledGuest || ownHoldQuantity <= 0) {
@@ -278,32 +369,26 @@ export function EventTicketPanel({
     }
   }, [settledGuest, timeslot.id])
 
-  // Single reserve path via CheckoutForm.onReserveCheckoutHold (below). Avoid a parallel
-  // useEffect reserve — concurrent creates race on unique email and break Payment Element.
-
   const reserveGuestHold = useCallback(
     async (metadata: Record<string, string>) => {
       if (!settledGuest) return
       const attempt = checkoutAttemptRef.current
       const qty = Math.max(1, parseInt(metadata.quantity ?? String(quantity), 10) || quantity)
-      const res = await fetch('/api/events/guest-reserve-hold', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          timeslotId: timeslot.id,
-          quantity: qty,
-          guestName: settledGuest.name,
-          guestEmail: settledGuest.email,
-          checkoutSessionId: settledGuest.checkoutSessionId,
-        }),
-      })
-      const data = (await res.json().catch(() => null)) as
-        | { holdId?: number | null; abandoned?: boolean; error?: string }
-        | null
-      if (!res.ok) {
-        throw new Error(data?.error || 'Unable to reserve places')
+      // CheckoutForm remounts after Continue already reserved the same qty — skip the
+      // network hop when nothing changed (mutex still serializes genuine overlaps).
+      if (lastReservedQtyRef.current === qty && ownHoldQuantity === qty) {
+        return undefined
       }
-      if (data?.abandoned || attempt !== checkoutAttemptRef.current) {
+      const result = await postGuestReserve({
+        name: settledGuest.name,
+        email: settledGuest.email,
+        checkoutSessionId: settledGuest.checkoutSessionId,
+        quantity: qty,
+      })
+      if (result.error) {
+        throw new Error(result.error)
+      }
+      if (result.abandoned || attempt !== checkoutAttemptRef.current) {
         releaseGuestCheckoutHold({
           timeslotId: timeslot.id,
           guestEmail: settledGuest.email,
@@ -311,13 +396,13 @@ export function EventTicketPanel({
           sync: false,
         })
         setOwnHoldQuantity(0)
+        lastReservedQtyRef.current = 0
         writeStoredGuestCheckout(timeslot.id, null)
         return
       }
-      setOwnHoldQuantity(qty)
-      return data?.holdId != null ? { holdId: String(data.holdId) } : undefined
+      return result.holdId != null ? { holdId: result.holdId } : undefined
     },
-    [settledGuest, timeslot.id, quantity],
+    [settledGuest, timeslot.id, quantity, ownHoldQuantity, postGuestReserve],
   )
   const pricing = useMemo(
     () =>
@@ -380,6 +465,7 @@ export function EventTicketPanel({
     if (settledGuest) {
       setSettledGuest(null)
       setOwnHoldQuantity(0)
+      lastReservedQtyRef.current = 0
       writeStoredGuestCheckout(timeslot.id, null)
     }
     if (guestFormError) setGuestFormError(null)
@@ -404,37 +490,24 @@ export function EventTicketPanel({
     setIsReserving(true)
 
     try {
-      const res = await fetch('/api/events/guest-reserve-hold', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          timeslotId: timeslot.id,
-          quantity,
-          guestName: name,
-          guestEmail: email,
-          checkoutSessionId,
-        }),
-      })
-      const data = (await res.json().catch(() => null)) as
-        | { error?: string; abandoned?: boolean }
-        | null
-      if (!res.ok || data?.abandoned) {
-        setSettledGuest(null)
-        setOwnHoldQuantity(0)
-        writeStoredGuestCheckout(timeslot.id, null)
-        setGuestFormError(data?.error || 'Unable to reserve places. Please try again.')
-        return
-      }
-      setOwnHoldQuantity(quantity)
-      writeStoredGuestCheckout(timeslot.id, {
+      const result = await postGuestReserve({
         name,
         email,
+        checkoutSessionId,
         quantity,
-        ownHoldQuantity: quantity,
       })
+      if (result.error || result.abandoned) {
+        setSettledGuest(null)
+        setOwnHoldQuantity(0)
+        lastReservedQtyRef.current = 0
+        writeStoredGuestCheckout(timeslot.id, null)
+        setGuestFormError(result.error || 'Unable to reserve places. Please try again.')
+        return
+      }
     } catch {
       setSettledGuest(null)
       setOwnHoldQuantity(0)
+      lastReservedQtyRef.current = 0
       writeStoredGuestCheckout(timeslot.id, null)
       setGuestFormError('Unable to reserve places. Please try again.')
       return

--- a/apps/atnd-me/src/components/events/EventTicketPanel.tsx
+++ b/apps/atnd-me/src/components/events/EventTicketPanel.tsx
@@ -647,11 +647,11 @@ export function EventTicketPanel({
               </p>
             ) : null}
 
-            {!settledGuest ? (
+            {!settledGuest || isReserving || ownHoldQuantity <= 0 ? (
               <Button
                 type="submit"
                 className="w-full"
-                disabled={!canContinue || isReserving}
+                disabled={!canContinue || isReserving || Boolean(settledGuest)}
                 data-testid="guest-checkout-continue"
               >
                 {isReserving ? 'Reserving…' : 'Continue to payment'}
@@ -659,7 +659,7 @@ export function EventTicketPanel({
             ) : null}
           </form>
 
-          {settledGuest ? (
+          {settledGuest && !isReserving && ownHoldQuantity > 0 ? (
             <CheckoutForm
               price={classPrice}
               priceComponent={
@@ -685,11 +685,13 @@ export function EventTicketPanel({
                 checkoutSessionId: settledGuest.checkoutSessionId,
               }}
             />
-          ) : (
+          ) : settledGuest && isReserving ? (
+            <p className="text-sm text-muted-foreground">Reserving your places…</p>
+          ) : !settledGuest ? (
             <p className="text-sm text-muted-foreground">
               Enter your details, then continue when your email is complete.
             </p>
-          )}
+          ) : null}
         </div>
       )}
     </aside>

--- a/apps/atnd-me/src/components/events/eventPageTypes.ts
+++ b/apps/atnd-me/src/components/events/eventPageTypes.ts
@@ -9,6 +9,10 @@ export type EventPageTimeslot = {
   endTime: string
   active?: boolean | null
   remainingCapacity?: number | null
+  /** places − confirmed only (ignores checkout holds). */
+  remainingConfirmedOnly?: number | null
+  /** Active checkout hold quantity for the authenticated viewer, if any. */
+  ownHoldQuantity?: number | null
   location?: string | null
   tenant: number | { id: number }
   branch?: (number | null) | Location

--- a/apps/atnd-me/src/components/events/eventPlacesAvailability.ts
+++ b/apps/atnd-me/src/components/events/eventPlacesAvailability.ts
@@ -1,9 +1,12 @@
 /**
  * Event ticket availability for display / sold-out gating.
  *
- * Global `remainingCapacity` subtracts everyone's active checkout holds. Unpaid holds must
- * not hard-sold-out the page (only confirmed bookings do). A viewer who already holds spots
- * must still reach checkout when global remaining is 0 because of their own hold.
+ * Global `remainingCapacity` subtracts everyone's active checkout holds — including the
+ * viewer's. Unpaid holds must not hard-sold-out the page (only confirmed bookings do).
+ * The places label adds the viewer's own hold back so they are not charged for their seat.
+ *
+ * Callers that create a hold against a stale SSR remaining must decrement `remainingCapacity`
+ * locally when the hold is applied (same pattern as manage-booking: remaining + ownHold).
  */
 export type EventPlacesAvailability = {
   /** Hard sell-out: confirmed bookings fill the event. */
@@ -29,9 +32,11 @@ export function eventPlacesAvailability(opts: {
   // Own hold: keep checkout available even when global remaining is 0 (holds fill the room).
   const temporarilyUnavailable =
     !soldOut && remainingCapacity <= 0 && ownHoldQuantity <= 0
-  // Prefer live global remaining; when it is 0 only because of our hold, show our reserved qty.
-  const viewerRemaining =
-    remainingCapacity > 0 ? remainingCapacity : ownHoldQuantity > 0 ? ownHoldQuantity : 0
+  // Global remaining already subtracts this viewer's hold — add it back for their label.
+  const viewerRemaining = Math.min(
+    remainingConfirmedOnly,
+    remainingCapacity + ownHoldQuantity,
+  )
   return { soldOut, temporarilyUnavailable, viewerRemaining }
 }
 

--- a/apps/atnd-me/src/components/events/eventPlacesAvailability.ts
+++ b/apps/atnd-me/src/components/events/eventPlacesAvailability.ts
@@ -1,0 +1,53 @@
+/**
+ * Event ticket availability for display / sold-out gating.
+ *
+ * Global `remainingCapacity` subtracts everyone's active checkout holds. Unpaid holds must
+ * not hard-sold-out the page (only confirmed bookings do). A viewer who already holds spots
+ * must still reach checkout when global remaining is 0 because of their own hold.
+ */
+export type EventPlacesAvailability = {
+  /** Hard sell-out: confirmed bookings fill the event. */
+  soldOut: boolean
+  /** Soft block: holds fill free spots, but confirmed capacity remains — and viewer has no hold. */
+  temporarilyUnavailable: boolean
+  /** Remaining capacity shown in the places label for this viewer. */
+  viewerRemaining: number
+}
+
+export function eventPlacesAvailability(opts: {
+  /** places − confirmed − all active holds (from SSR / API) */
+  remainingCapacity: number
+  /** places − confirmed (ignores holds) */
+  remainingConfirmedOnly: number
+  /** Active hold quantity for the current viewer, if any */
+  ownHoldQuantity?: number
+}): EventPlacesAvailability {
+  const ownHoldQuantity = Math.max(0, opts.ownHoldQuantity ?? 0)
+  const remainingCapacity = Math.max(0, opts.remainingCapacity)
+  const remainingConfirmedOnly = Math.max(0, opts.remainingConfirmedOnly)
+  const soldOut = remainingConfirmedOnly <= 0
+  // Own hold: keep checkout available even when global remaining is 0 (holds fill the room).
+  const temporarilyUnavailable =
+    !soldOut && remainingCapacity <= 0 && ownHoldQuantity <= 0
+  // Prefer live global remaining; when it is 0 only because of our hold, show our reserved qty.
+  const viewerRemaining =
+    remainingCapacity > 0 ? remainingCapacity : ownHoldQuantity > 0 ? ownHoldQuantity : 0
+  return { soldOut, temporarilyUnavailable, viewerRemaining }
+}
+
+export function eventPlacesLabel(remaining: number): string {
+  if (remaining <= 0) return 'Sold out'
+  if (remaining === 1) return '1 place left'
+  return `${remaining} places left`
+}
+
+export function guestCheckoutHoldStorageKey(timeslotId: number | string): string {
+  return `atnd-me:event-guest-checkout:${timeslotId}`
+}
+
+export type StoredGuestCheckout = {
+  name: string
+  email: string
+  quantity: number
+  ownHoldQuantity: number
+}

--- a/apps/atnd-me/src/components/events/loadEventTimeslot.ts
+++ b/apps/atnd-me/src/components/events/loadEventTimeslot.ts
@@ -3,7 +3,12 @@ import { headers } from 'next/headers'
 import { getPayload } from '@/lib/payload'
 import { getTenantWithBranding } from '@/utilities/getTenantContext'
 import { ATND_ME_BOOKINGS_COLLECTION_SLUGS } from '@/constants/bookings-collection-slugs'
-import { computeRemainingCapacityWithHolds, CHECKOUT_HOLD_COLLECTION_SLUG } from '@repo/bookings-payments'
+import {
+  computeCapacityBreakdownWithHolds,
+  getActiveCheckoutHold,
+  CHECKOUT_HOLD_COLLECTION_SLUG,
+} from '@repo/bookings-payments'
+import { currentUser } from '@/lib/auth/context/get-context-props'
 import {
   type EventPageTimeslot,
   relationId,
@@ -30,12 +35,30 @@ export async function loadEventTimeslot(id: number): Promise<EventPageTimeslot |
     return null
   }
 
-  const remainingCapacity = await computeRemainingCapacityWithHolds(payload, id, {
+  const capacity = await computeCapacityBreakdownWithHolds(payload, id, {
     timeslotsSlug: ATND_ME_BOOKINGS_COLLECTION_SLUGS.timeslots,
     eventTypesSlug: ATND_ME_BOOKINGS_COLLECTION_SLUGS.eventTypes,
     bookingsSlug: ATND_ME_BOOKINGS_COLLECTION_SLUGS.bookings,
     holdCollection: CHECKOUT_HOLD_COLLECTION_SLUG,
   })
 
-  return { ...timeslot, remainingCapacity }
+  let ownHoldQuantity = 0
+  const user = await currentUser()
+  if (user?.id != null) {
+    const hold = await getActiveCheckoutHold(payload, {
+      timeslotId: id,
+      userId: Number(user.id),
+      holdCollection: CHECKOUT_HOLD_COLLECTION_SLUG,
+    })
+    if (hold) {
+      ownHoldQuantity = Math.max(0, Number(hold.quantity) || 0)
+    }
+  }
+
+  return {
+    ...timeslot,
+    remainingCapacity: capacity.remaining,
+    remainingConfirmedOnly: capacity.remainingConfirmedOnly,
+    ownHoldQuantity,
+  }
 }

--- a/apps/atnd-me/src/constants/bookings-collection-slugs.ts
+++ b/apps/atnd-me/src/constants/bookings-collection-slugs.ts
@@ -12,4 +12,6 @@ export const ATND_ME_BOOKINGS_COLLECTION_SLUGS = {
   bookings: 'bookings',
   classPasses: 'class-passes',
   classPassTypes: 'class-pass-types',
+  courseEnrollments: 'course-enrollments',
+  courses: 'courses',
 } as const satisfies BookingCollectionSlugs & TRPCBookingCollectionSlugs

--- a/apps/atnd-me/src/fields/courseEmailFields.ts
+++ b/apps/atnd-me/src/fields/courseEmailFields.ts
@@ -1,0 +1,77 @@
+import type { Field } from 'payload'
+import { buildFormStyleEmailsField } from './formEmailFields'
+import { COURSE_EMAIL_SEND_TIMINGS } from '@/lib/course-email/resolve-send-time'
+
+export const COURSE_EMAIL_SEND_TIMING_OPTIONS = [
+  { label: 'Directly after purchase', value: 'after_purchase' },
+  { label: 'One week before course start', value: 'one_week_before_start' },
+  { label: 'One day before course start', value: 'one_day_before_start' },
+  { label: 'One day after course start', value: 'one_day_after_start' },
+  { label: 'One day before course end', value: 'one_day_before_end' },
+  { label: 'One day after course end', value: 'one_day_after_end' },
+] as const satisfies ReadonlyArray<{
+  label: string
+  value: (typeof COURSE_EMAIL_SEND_TIMINGS)[number]
+}>
+
+const courseEmailSendTimingField: Field = {
+  name: 'sendTiming',
+  type: 'select',
+  label: 'When to send',
+  required: true,
+  defaultValue: 'after_purchase',
+  options: [...COURSE_EMAIL_SEND_TIMING_OPTIONS],
+}
+
+const courseEmailRecipientRowField: Field = {
+  type: 'row',
+  fields: [
+    {
+      name: 'cc',
+      type: 'text',
+      label: 'CC',
+      admin: { style: { maxWidth: '50%' } },
+    },
+    {
+      name: 'bcc',
+      type: 'text',
+      label: 'BCC',
+      admin: { style: { maxWidth: '50%' } },
+    },
+  ],
+}
+
+const courseEmailSenderRowField: Field = {
+  type: 'row',
+  fields: [
+    {
+      name: 'replyTo',
+      type: 'text',
+      label: 'Reply To',
+      required: true,
+      admin: {
+        placeholder: '"Reply To" <reply-to@email.com>',
+        width: '50%',
+      },
+    },
+    {
+      name: 'emailFrom',
+      type: 'text',
+      label: 'Email From',
+      admin: {
+        placeholder: '"Email From" <email-from@email.com>',
+        width: '50%',
+      },
+    },
+  ],
+}
+
+export const courseEmailsField = buildFormStyleEmailsField({
+  name: 'courseEmails',
+  label: 'Course emails',
+  description:
+    'Emails sent to the enrollee after purchase or relative to their access window (start/end). Scheduled emails send at 9:00 local.',
+  recipientFields: courseEmailRecipientRowField,
+  senderFields: courseEmailSenderRowField,
+  additionalFields: [courseEmailSendTimingField],
+})

--- a/apps/atnd-me/src/fields/defaultLexical.ts
+++ b/apps/atnd-me/src/fields/defaultLexical.ts
@@ -1,13 +1,10 @@
-import type { TextFieldSingleValidation } from 'payload'
 import {
   BlocksFeature,
   FixedToolbarFeature,
   HeadingFeature,
   HorizontalRuleFeature,
   InlineToolbarFeature,
-  LinkFeature,
   lexicalEditor,
-  type LinkFields,
 } from '@payloadcms/richtext-lexical'
 
 import { Banner } from '@/blocks/Banner/config'
@@ -16,37 +13,9 @@ import { EventCheckout } from '@/blocks/EventCheckout/config'
 import { GiftVoucherCheckout } from '@/blocks/GiftVoucherCheckout/config'
 import { Map } from '@/blocks/Map/config'
 import { MediaBlock } from '@/blocks/MediaBlock/config'
+import { pagesPostsLinkFeature } from '@/fields/lexicalLinkFeature'
 
 export { simpleLexical } from '@/fields/simpleLexical'
-
-const linkFeature = LinkFeature({
-  enabledCollections: ['pages', 'posts'],
-  fields: ({ defaultFields }) => {
-    const defaultFieldsWithoutUrl = defaultFields.filter((field) => {
-      if ('name' in field && field.name === 'url') return false
-      return true
-    })
-
-    return [
-      ...defaultFieldsWithoutUrl,
-      {
-        name: 'url',
-        type: 'text',
-        admin: {
-          condition: (_data, siblingData) => siblingData?.linkType !== 'internal',
-        },
-        label: ({ t }) => t('fields:enterURL'),
-        required: true,
-        validate: ((value, options) => {
-          if ((options?.siblingData as LinkFields)?.linkType === 'internal') {
-            return true
-          }
-          return value ? true : 'URL is required'
-        }) as TextFieldSingleValidation,
-      },
-    ]
-  },
-})
 
 /**
  * Single shared rich-text editor for atnd-me.
@@ -65,7 +34,7 @@ export const defaultLexical = lexicalEditor({
 
     return [
       ...withoutLink,
-      linkFeature,
+      pagesPostsLinkFeature,
       HeadingFeature({ enabledHeadingSizes: ['h1', 'h2', 'h3', 'h4'] }),
       BlocksFeature({
         blocks: [Banner, Code, MediaBlock, EventCheckout, GiftVoucherCheckout, Map],

--- a/apps/atnd-me/src/fields/lexicalLinkFeature.ts
+++ b/apps/atnd-me/src/fields/lexicalLinkFeature.ts
@@ -1,0 +1,32 @@
+import type { TextFieldSingleValidation } from 'payload'
+import { LinkFeature, type LinkFields } from '@payloadcms/richtext-lexical'
+
+/** Internal doc links limited to pages/posts (not bookings collections like timeslots). */
+export const pagesPostsLinkFeature = LinkFeature({
+  enabledCollections: ['pages', 'posts'],
+  fields: ({ defaultFields }) => {
+    const defaultFieldsWithoutUrl = defaultFields.filter((field) => {
+      if ('name' in field && field.name === 'url') return false
+      return true
+    })
+
+    return [
+      ...defaultFieldsWithoutUrl,
+      {
+        name: 'url',
+        type: 'text',
+        admin: {
+          condition: (_data, siblingData) => siblingData?.linkType !== 'internal',
+        },
+        label: ({ t }) => t('fields:enterURL'),
+        required: true,
+        validate: ((value, options) => {
+          if ((options?.siblingData as LinkFields)?.linkType === 'internal') {
+            return true
+          }
+          return value ? true : 'URL is required'
+        }) as TextFieldSingleValidation,
+      },
+    ]
+  },
+})

--- a/apps/atnd-me/src/fields/simpleLexical.ts
+++ b/apps/atnd-me/src/fields/simpleLexical.ts
@@ -4,15 +4,21 @@ import {
   lexicalEditor,
 } from '@payloadcms/richtext-lexical'
 
+import { pagesPostsLinkFeature } from '@/fields/lexicalLinkFeature'
+
 /**
  * Nested / caption rich text — no BlocksFeature (avoids Banner → Banner recursion
  * and circular imports with defaultLexical).
- * Still gets lists, bold/italic, links, etc. from Payload defaultFeatures.
+ * Still gets lists, bold/italic, etc. from Payload defaultFeatures.
+ * Replaces the default LinkFeature so internal links only target pages/posts.
  */
 export const simpleLexical = lexicalEditor({
-  features: ({ defaultFeatures }) => [
-    ...defaultFeatures,
-    FixedToolbarFeature(),
-    InlineToolbarFeature(),
-  ],
+  features: ({ defaultFeatures }) => {
+    const withoutLink = defaultFeatures.filter((feature) => {
+      const key = (feature as { key?: string } | null | undefined)?.key
+      return key !== 'link'
+    })
+
+    return [...withoutLink, pagesPostsLinkFeature, FixedToolbarFeature(), InlineToolbarFeature()]
+  },
 })

--- a/apps/atnd-me/src/globals/PlatformFees/index.ts
+++ b/apps/atnd-me/src/globals/PlatformFees/index.ts
@@ -41,6 +41,14 @@ export const PlatformFees: GlobalConfig = {
           admin: { description: 'Default fee for class pass bookings.' },
         },
         {
+          name: 'coursePercent',
+          type: 'number',
+          label: 'Course (%)',
+          required: true,
+          defaultValue: 3,
+          admin: { description: 'Default fee for course enrollments.' },
+        },
+        {
           name: 'subscriptionPercent',
           type: 'number',
           label: 'Subscription (%)',
@@ -81,6 +89,12 @@ export const PlatformFees: GlobalConfig = {
           name: 'classPassPercent',
           type: 'number',
           label: 'Class pass (%)',
+          admin: { description: 'Leave empty to use default.' },
+        },
+        {
+          name: 'coursePercent',
+          type: 'number',
+          label: 'Course (%)',
           admin: { description: 'Leave empty to use default.' },
         },
         {

--- a/apps/atnd-me/src/lib/booking/releaseGuestCheckoutHold.ts
+++ b/apps/atnd-me/src/lib/booking/releaseGuestCheckoutHold.ts
@@ -22,6 +22,8 @@ export type ReleaseGuestCheckoutHoldResult =
 export function releaseGuestCheckoutHold(options: {
   timeslotId: number | string
   guestEmail: string
+  /** Client checkout attempt id — blocks late upserts for this session after release. */
+  checkoutSessionId?: string | null
   /** Prefer unload-safe transport (required for pagehide / beforeunload). */
   sync?: boolean
   /** e.g. payment redirect in progress — do not release. */
@@ -35,6 +37,9 @@ export function releaseGuestCheckoutHold(options: {
   const body = JSON.stringify({
     timeslotId: options.timeslotId,
     guestEmail: options.guestEmail,
+    ...(options.checkoutSessionId
+      ? { checkoutSessionId: options.checkoutSessionId }
+      : {}),
   })
 
   const XMLHttpRequestCtor =

--- a/apps/atnd-me/src/lib/course-email/cancel-scheduled-course-email.ts
+++ b/apps/atnd-me/src/lib/course-email/cancel-scheduled-course-email.ts
@@ -1,0 +1,86 @@
+import type { PayloadRequest } from 'payload'
+import { COURSE_EMAIL_DELIVERIES_SLUG } from '@/collections/CourseEmailDeliveries'
+
+async function findCourseEmailJobByDeliveryId(
+  req: PayloadRequest,
+  deliveryId: number,
+): Promise<{ id: number } | null> {
+  const result = await req.payload.find({
+    collection: 'payload-jobs',
+    where: {
+      and: [
+        { taskSlug: { equals: 'sendCourseEmail' } },
+        { completedAt: { exists: false } },
+      ],
+    },
+    sort: '-createdAt',
+    limit: 25,
+    depth: 0,
+    overrideAccess: true,
+  })
+
+  const match = result.docs.find((doc) => {
+    const input = doc.input
+    if (input == null || typeof input !== 'object' || Array.isArray(input)) return false
+    const deliveryIdFromInput = (input as { deliveryId?: unknown }).deliveryId
+    return deliveryIdFromInput === deliveryId || deliveryIdFromInput === String(deliveryId)
+  })
+
+  return match?.id != null ? { id: match.id as number } : null
+}
+
+async function cancelPayloadJob(req: PayloadRequest, jobId: number): Promise<void> {
+  const jobsApi = req.payload.jobs as {
+    cancelByID?: (args: { id: number | string; req?: PayloadRequest }) => Promise<unknown>
+  }
+  if (typeof jobsApi.cancelByID === 'function') {
+    try {
+      await jobsApi.cancelByID({ id: jobId, req })
+      return
+    } catch {
+      // fall through
+    }
+  }
+  await req.payload.delete({
+    collection: 'payload-jobs',
+    id: jobId,
+    overrideAccess: true,
+    req,
+  })
+}
+
+export async function maybeCancelScheduledCourseEmails(
+  req: PayloadRequest,
+  enrollmentId: number,
+): Promise<void> {
+  const scheduled = await req.payload.find({
+    collection: COURSE_EMAIL_DELIVERIES_SLUG,
+    where: {
+      and: [
+        { enrollment: { equals: enrollmentId } },
+        { status: { equals: 'scheduled' } },
+      ],
+    },
+    limit: 50,
+    depth: 0,
+    overrideAccess: true,
+  })
+
+  for (const delivery of scheduled.docs) {
+    const deliveryId = delivery.id as number
+    const job =
+      typeof delivery.payloadJobId === 'number'
+        ? { id: delivery.payloadJobId }
+        : await findCourseEmailJobByDeliveryId(req, deliveryId)
+    if (job) {
+      await cancelPayloadJob(req, job.id)
+    }
+    await req.payload.update({
+      collection: COURSE_EMAIL_DELIVERIES_SLUG,
+      id: deliveryId,
+      data: { status: 'cancelled' },
+      overrideAccess: true,
+      req,
+    })
+  }
+}

--- a/apps/atnd-me/src/lib/course-email/cancel-transition.ts
+++ b/apps/atnd-me/src/lib/course-email/cancel-transition.ts
@@ -1,0 +1,13 @@
+export function isCancelledEnrollmentTransition({
+  doc,
+  previousDoc,
+  operation,
+}: {
+  doc: { status?: string }
+  previousDoc?: { status?: string } | null
+  operation: 'create' | 'update'
+}): boolean {
+  if (operation !== 'update') return false
+  if (doc.status !== 'cancelled') return false
+  return previousDoc?.status !== 'cancelled'
+}

--- a/apps/atnd-me/src/lib/course-email/maybe-trigger-course-email.ts
+++ b/apps/atnd-me/src/lib/course-email/maybe-trigger-course-email.ts
@@ -1,0 +1,301 @@
+import type { CollectionAfterChangeHook, PayloadRequest } from 'payload'
+import { COURSE_EMAIL_DELIVERIES_SLUG } from '@/collections/CourseEmailDeliveries'
+import { resolveCourseEmailSendAt } from '@/lib/course-email/resolve-send-time'
+import { isCancelledEnrollmentTransition } from '@/lib/course-email/cancel-transition'
+import { maybeCancelScheduledCourseEmails } from '@/lib/course-email/cancel-scheduled-course-email'
+import { sendCourseEmail } from '@/lib/course-email/send-course-email'
+import {
+  resolveActiveCourseEmailConfigs,
+  type ActiveCourseEmailConfig,
+} from '@/lib/course-email/types'
+import { resolveTimeZone } from '@repo/shared-utils'
+
+function relationId(value: unknown): number | null {
+  if (value == null) return null
+  if (typeof value === 'object' && value !== null && 'id' in value) {
+    const id = (value as { id?: unknown }).id
+    if (typeof id === 'number') return id
+    if (typeof id === 'string' && /^\d+$/.test(id)) return parseInt(id, 10)
+  }
+  if (typeof value === 'number') return value
+  if (typeof value === 'string' && /^\d+$/.test(value)) return parseInt(value, 10)
+  return null
+}
+
+function scheduleOnNextEventLoop(fn: () => void): void {
+  const g = globalThis as typeof globalThis & {
+    setImmediate?: (_cb: () => void) => void
+  }
+  if (typeof g.setImmediate === 'function') {
+    g.setImmediate(fn)
+  } else {
+    setTimeout(fn, 0)
+  }
+}
+
+function isActiveEnrollmentTransition({
+  doc,
+  previousDoc,
+  operation,
+}: {
+  doc: { status?: string }
+  previousDoc?: { status?: string } | null
+  operation: 'create' | 'update'
+}): boolean {
+  if (doc.status !== 'active') return false
+  if (operation === 'create') return true
+  return previousDoc?.status !== 'active'
+}
+
+async function findExistingDelivery(
+  req: PayloadRequest,
+  key: {
+    tenantId: number
+    userId: number
+    enrollmentId: number
+    courseId: number
+    emailConfigId: string
+  },
+) {
+  const result = await req.payload.find({
+    collection: COURSE_EMAIL_DELIVERIES_SLUG,
+    where: {
+      and: [
+        { tenant: { equals: key.tenantId } },
+        { user: { equals: key.userId } },
+        { enrollment: { equals: key.enrollmentId } },
+        { course: { equals: key.courseId } },
+        { emailConfigId: { equals: key.emailConfigId } },
+      ],
+    },
+    limit: 1,
+    depth: 0,
+    overrideAccess: true,
+  })
+  return result.docs[0] ?? null
+}
+
+async function maybeTriggerSingleCourseEmail({
+  req,
+  enrollmentId,
+  courseId,
+  tenantId,
+  userId,
+  user,
+  accessStartsAt,
+  accessEndsAt,
+  timeZone,
+  config,
+}: {
+  req: PayloadRequest
+  enrollmentId: number
+  courseId: number
+  tenantId: number
+  userId: number
+  user: unknown
+  accessStartsAt: string
+  accessEndsAt: string
+  timeZone: string
+  config: ActiveCourseEmailConfig
+}): Promise<void> {
+  const existing = await findExistingDelivery(req, {
+    tenantId,
+    userId,
+    enrollmentId,
+    courseId,
+    emailConfigId: config.id,
+  })
+  if (existing) return
+
+  const sendAt = resolveCourseEmailSendAt({
+    sendTiming: config.sendTiming,
+    accessStartsAt,
+    accessEndsAt,
+    timeZone,
+  })
+
+  if (sendAt.kind === 'skip') return
+
+  if (sendAt.kind === 'immediate') {
+    const delivery = await req.payload.create({
+      collection: COURSE_EMAIL_DELIVERIES_SLUG,
+      data: {
+        tenant: tenantId,
+        user: userId,
+        enrollment: enrollmentId,
+        course: courseId,
+        emailConfigId: config.id,
+        sendTiming: config.sendTiming,
+        status: 'scheduled',
+      },
+      overrideAccess: true,
+      req,
+    })
+
+    scheduleOnNextEventLoop(() => {
+      void (async () => {
+        try {
+          await sendCourseEmail({ payload: req.payload, user, config })
+          await req.payload.update({
+            collection: COURSE_EMAIL_DELIVERIES_SLUG,
+            id: delivery.id,
+            data: { status: 'sent', sentAt: new Date().toISOString() },
+            overrideAccess: true,
+          })
+        } catch (err) {
+          req.payload.logger?.error?.(
+            `[course-email] immediate send failed: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          )
+          await req.payload
+            .delete({
+              collection: COURSE_EMAIL_DELIVERIES_SLUG,
+              id: delivery.id,
+              overrideAccess: true,
+            })
+            .catch(() => {})
+        }
+      })()
+    })
+    return
+  }
+
+  const delivery = await req.payload.create({
+    collection: COURSE_EMAIL_DELIVERIES_SLUG,
+    data: {
+      tenant: tenantId,
+      user: userId,
+      enrollment: enrollmentId,
+      course: courseId,
+      emailConfigId: config.id,
+      sendTiming: config.sendTiming,
+      status: 'scheduled',
+      scheduledFor: sendAt.sendAt.toISOString(),
+    },
+    overrideAccess: true,
+    req,
+  })
+
+  const job = await req.payload.jobs.queue({
+    task: 'sendCourseEmail',
+    input: {
+      deliveryId: delivery.id,
+      userId,
+      enrollmentId,
+      tenantId,
+      courseId,
+      emailConfigId: config.id,
+    },
+    waitUntil: sendAt.sendAt,
+    req,
+  })
+
+  if (job?.id != null) {
+    await req.payload.update({
+      collection: COURSE_EMAIL_DELIVERIES_SLUG,
+      id: delivery.id,
+      data: { payloadJobId: Number(job.id) },
+      overrideAccess: true,
+      req,
+    })
+  }
+}
+
+export const triggerCourseEmailAfterChange: CollectionAfterChangeHook = async ({
+  doc,
+  previousDoc,
+  operation,
+  req,
+}) => {
+  if (
+    isCancelledEnrollmentTransition({
+      doc,
+      previousDoc,
+      operation,
+    })
+  ) {
+    const enrollmentId = relationId(doc.id)
+    if (enrollmentId != null) {
+      await maybeCancelScheduledCourseEmails(req, enrollmentId)
+    }
+    return doc
+  }
+
+  if (!isActiveEnrollmentTransition({ doc, previousDoc, operation })) {
+    return doc
+  }
+
+  const enrollmentId = relationId(doc.id)
+  const userId = relationId(doc.user)
+  const courseId = relationId(doc.course)
+  const tenantId = relationId(doc.tenant)
+  const accessStartsAt =
+    typeof doc.accessStartsAt === 'string' ? doc.accessStartsAt : null
+  const accessEndsAt = typeof doc.accessEndsAt === 'string' ? doc.accessEndsAt : null
+
+  if (
+    enrollmentId == null ||
+    userId == null ||
+    courseId == null ||
+    tenantId == null ||
+    !accessStartsAt ||
+    !accessEndsAt
+  ) {
+    return doc
+  }
+
+  const course = await req.payload
+    .findByID({
+      collection: 'courses' as import('payload').CollectionSlug,
+      id: courseId,
+      depth: 0,
+      overrideAccess: true,
+    })
+    .catch(() => null)
+
+  const configs = resolveActiveCourseEmailConfigs(
+    course as { courseEmails?: Parameters<typeof resolveActiveCourseEmailConfigs>[0]['courseEmails'] },
+  )
+  if (configs.length === 0) return doc
+
+  const tenant = await req.payload
+    .findByID({
+      collection: 'tenants',
+      id: tenantId,
+      depth: 0,
+      overrideAccess: true,
+    })
+    .catch(() => null)
+  const timeZone = resolveTimeZone(
+    tenant && typeof tenant === 'object' && 'timeZone' in tenant
+      ? (tenant as { timeZone?: string | null }).timeZone || undefined
+      : undefined,
+  )
+
+  const user = await req.payload
+    .findByID({
+      collection: 'users',
+      id: userId,
+      depth: 0,
+      overrideAccess: true,
+    })
+    .catch(() => null)
+
+  for (const config of configs) {
+    await maybeTriggerSingleCourseEmail({
+      req,
+      enrollmentId,
+      courseId,
+      tenantId,
+      userId,
+      user,
+      accessStartsAt,
+      accessEndsAt,
+      timeZone,
+      config,
+    })
+  }
+
+  return doc
+}

--- a/apps/atnd-me/src/lib/course-email/resolve-send-time.ts
+++ b/apps/atnd-me/src/lib/course-email/resolve-send-time.ts
@@ -1,0 +1,81 @@
+import { TZDate } from '@date-fns/tz'
+import { getZonedDateParts } from '@repo/shared-utils'
+
+export const COURSE_EMAIL_SEND_TIMINGS = [
+  'after_purchase',
+  'one_week_before_start',
+  'one_day_before_start',
+  'one_day_after_start',
+  'one_day_before_end',
+  'one_day_after_end',
+] as const
+
+export type CourseEmailSendTiming = (typeof COURSE_EMAIL_SEND_TIMINGS)[number]
+
+const SEND_HOUR = 9
+
+export type ResolveCourseEmailSendAtArgs = {
+  sendTiming: CourseEmailSendTiming
+  accessStartsAt: string
+  accessEndsAt: string
+  timeZone: string
+  now?: Date
+}
+
+export type ResolveCourseEmailSendAtResult =
+  | { kind: 'immediate' }
+  | { kind: 'scheduled'; sendAt: Date }
+  | { kind: 'skip'; reason: 'send_time_past' }
+
+function atLocal9amRelativeTo(
+  anchorIso: string,
+  timeZone: string,
+  dayOffset: number,
+): Date {
+  const { year, month, date } = getZonedDateParts(anchorIso, timeZone)
+  return new TZDate(year, month, date + dayOffset, SEND_HOUR, 0, 0, 0, timeZone)
+}
+
+/**
+ * Resolve when a course email should send.
+ * Calendar timings use enrollment access window + 9:00 local (same as post-booking next-day).
+ */
+export function resolveCourseEmailSendAt(
+  args: ResolveCourseEmailSendAtArgs,
+): ResolveCourseEmailSendAtResult {
+  const { sendTiming, accessStartsAt, accessEndsAt, timeZone } = args
+  const now = args.now ?? new Date()
+
+  if (sendTiming === 'after_purchase') {
+    return { kind: 'immediate' }
+  }
+
+  let sendAt: Date
+  switch (sendTiming) {
+    case 'one_week_before_start':
+      sendAt = atLocal9amRelativeTo(accessStartsAt, timeZone, -7)
+      break
+    case 'one_day_before_start':
+      sendAt = atLocal9amRelativeTo(accessStartsAt, timeZone, -1)
+      break
+    case 'one_day_after_start':
+      sendAt = atLocal9amRelativeTo(accessStartsAt, timeZone, 1)
+      break
+    case 'one_day_before_end':
+      sendAt = atLocal9amRelativeTo(accessEndsAt, timeZone, -1)
+      break
+    case 'one_day_after_end':
+      sendAt = atLocal9amRelativeTo(accessEndsAt, timeZone, 1)
+      break
+    default: {
+      const _exhaustive: never = sendTiming
+      throw new Error(`Unknown course email sendTiming: ${_exhaustive}`)
+    }
+  }
+
+  if (sendAt.getTime() <= now.getTime()) {
+    return { kind: 'skip', reason: 'send_time_past' }
+  }
+
+  return { kind: 'scheduled', sendAt }
+}

--- a/apps/atnd-me/src/lib/course-email/send-course-email.ts
+++ b/apps/atnd-me/src/lib/course-email/send-course-email.ts
@@ -1,0 +1,16 @@
+import type { BasePayload } from 'payload'
+import { sendPostBookingEmail } from '@/lib/post-booking-email/send-post-booking-email'
+import type { CourseEmailConfig } from './types'
+
+/** Reuse post-booking email renderer/sender — same subject + Lexical message shape. */
+export async function sendCourseEmail({
+  payload,
+  user,
+  config,
+}: {
+  payload: BasePayload
+  user: unknown
+  config: CourseEmailConfig
+}): Promise<void> {
+  await sendPostBookingEmail({ payload, user, config })
+}

--- a/apps/atnd-me/src/lib/course-email/types.ts
+++ b/apps/atnd-me/src/lib/course-email/types.ts
@@ -1,0 +1,53 @@
+import type { CourseEmailSendTiming } from '@/lib/course-email/resolve-send-time'
+
+export type CourseEmailConfig = {
+  id?: string | null
+  cc?: string | null
+  bcc?: string | null
+  replyTo?: string | null
+  emailFrom?: string | null
+  subject?: string | null
+  message?: unknown
+  sendTiming?: CourseEmailSendTiming | null
+}
+
+export type CourseEmailJobInput = {
+  deliveryId: number
+  userId: number
+  enrollmentId: number
+  tenantId: number
+  courseId: number
+  emailConfigId: string
+}
+
+export type ActiveCourseEmailConfig = CourseEmailConfig & {
+  id: string
+  subject: string
+  replyTo: string
+  sendTiming: CourseEmailSendTiming
+}
+
+function isValidCourseEmailConfig(
+  entry: CourseEmailConfig | null | undefined,
+): entry is ActiveCourseEmailConfig {
+  return Boolean(
+    entry?.id && entry.subject?.trim() && entry.sendTiming && entry.replyTo?.trim(),
+  )
+}
+
+export function resolveActiveCourseEmailConfigs(course: {
+  courseEmails?: CourseEmailConfig[] | null
+}): ActiveCourseEmailConfig[] {
+  const emails = course.courseEmails
+  if (!Array.isArray(emails)) return []
+  return emails.filter(isValidCourseEmailConfig)
+}
+
+export function resolveCourseEmailConfigById(
+  course: { courseEmails?: CourseEmailConfig[] | null },
+  emailConfigId: string,
+): ActiveCourseEmailConfig | null {
+  return (
+    resolveActiveCourseEmailConfigs(course).find((entry) => entry.id === emailConfigId) ?? null
+  )
+}

--- a/apps/atnd-me/src/lib/courses/format-course-access-window.ts
+++ b/apps/atnd-me/src/lib/courses/format-course-access-window.ts
@@ -1,0 +1,60 @@
+/**
+ * Public copy for course access window (fixed dates vs duration from purchase).
+ */
+
+export type CourseAccessWindowCopyInput = {
+  startDate?: string | null
+  endDate?: string | null
+  durationLength?: number | null
+  durationUnit?: 'days' | 'weeks' | null
+}
+
+const MONTHS = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+] as const
+
+function formatDay(iso: string): string {
+  const day = iso.trim().slice(0, 10)
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(day)
+  if (!match) return day
+  const year = Number(match[1])
+  const month = Number(match[2])
+  const date = Number(match[3])
+  if (!month || month < 1 || month > 12) return day
+  return `${date} ${MONTHS[month - 1]} ${year}`
+}
+
+export function formatCourseAccessWindowCopy(
+  course: CourseAccessWindowCopyInput,
+): string | null {
+  const start = typeof course.startDate === 'string' ? course.startDate.trim() : ''
+  const end = typeof course.endDate === 'string' ? course.endDate.trim() : ''
+  if (start && end) {
+    return `${formatDay(start)} – ${formatDay(end)}`
+  }
+
+  const length =
+    typeof course.durationLength === 'number' && course.durationLength >= 1
+      ? Math.floor(course.durationLength)
+      : null
+  const unit = course.durationUnit === 'days' || course.durationUnit === 'weeks'
+    ? course.durationUnit
+    : null
+  if (length != null && unit) {
+    const label = length === 1 ? unit.slice(0, -1) : unit
+    return `${length} ${label} from purchase`
+  }
+
+  return null
+}

--- a/apps/atnd-me/src/lib/courses/resolve-course-for-purchase.ts
+++ b/apps/atnd-me/src/lib/courses/resolve-course-for-purchase.ts
@@ -1,0 +1,74 @@
+/**
+ * Shared validation for auth + guest course purchase APIs.
+ */
+
+export type CourseForPurchase = {
+  id: number
+  status?: string | null
+  maxEnrollments?: number | null
+  priceInformation?: { price?: number | null } | null
+  tenant?: number | { id?: number | null } | null
+  startDate?: string | null
+  endDate?: string | null
+  durationLength?: number | null
+  durationUnit?: 'days' | 'weeks' | null
+}
+
+export type ResolveCourseForPurchaseResult =
+  | {
+      ok: true
+      course: CourseForPurchase
+      priceCents: number
+      tenantId: number
+    }
+  | { ok: false; status: number; error: string }
+
+function toTenantId(tenant: CourseForPurchase['tenant']): number | null {
+  if (typeof tenant === 'number' && Number.isFinite(tenant)) return tenant
+  if (tenant && typeof tenant === 'object' && typeof tenant.id === 'number') return tenant.id
+  return null
+}
+
+export function resolveCourseForPurchase(opts: {
+  course: CourseForPurchase | null | undefined
+  expectedTenantId: number
+  activeEnrollmentCount: number
+}): ResolveCourseForPurchaseResult {
+  const { course, expectedTenantId, activeEnrollmentCount } = opts
+  if (!course) {
+    return { ok: false, status: 404, error: 'Course not found' }
+  }
+
+  const tenantId = toTenantId(course.tenant)
+  if (tenantId == null || tenantId !== expectedTenantId) {
+    return { ok: false, status: 404, error: 'Course not found' }
+  }
+
+  if (course.status !== 'open') {
+    return { ok: false, status: 400, error: 'Course is not open for enrollment' }
+  }
+
+  const priceEur = course.priceInformation?.price
+  if (typeof priceEur !== 'number' || !(priceEur > 0)) {
+    return { ok: false, status: 400, error: 'Course has no price configured' }
+  }
+
+  if (
+    typeof course.maxEnrollments === 'number' &&
+    course.maxEnrollments >= 1 &&
+    activeEnrollmentCount >= course.maxEnrollments
+  ) {
+    return { ok: false, status: 400, error: 'Course is sold out' }
+  }
+
+  return {
+    ok: true,
+    course,
+    priceCents: Math.round(priceEur * 100),
+    tenantId,
+  }
+}
+
+export function isCompleteGuestEmail(email: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim())
+}

--- a/apps/atnd-me/src/lib/post-booking-email/maybe-trigger-post-booking-email.ts
+++ b/apps/atnd-me/src/lib/post-booking-email/maybe-trigger-post-booking-email.ts
@@ -202,26 +202,47 @@ async function maybeTriggerSinglePostBookingEmail({
           user,
           config,
         })
-        await req.payload.update({
-          collection: POST_BOOKING_EMAIL_DELIVERIES_SLUG,
-          id: delivery.id,
-          data: {
-            status: 'sent',
-            sentAt: new Date().toISOString(),
-          },
-          overrideAccess: true,
-        })
       } catch (error) {
         req.payload.logger.error(
           `[post-booking-email] Failed to send delivery ${delivery.id}: ${
             error instanceof Error ? error.message : String(error)
           }`,
         )
-        await req.payload.delete({
-          collection: POST_BOOKING_EMAIL_DELIVERIES_SLUG,
-          id: delivery.id,
-          overrideAccess: true,
-        }).catch(() => undefined)
+        await req.payload
+          .delete({
+            collection: POST_BOOKING_EMAIL_DELIVERIES_SLUG,
+            id: delivery.id,
+            overrideAccess: true,
+          })
+          .catch(() => undefined)
+        return
+      }
+
+      let markedSent = false
+      for (let attempt = 0; attempt < 3 && !markedSent; attempt += 1) {
+        try {
+          await req.payload.update({
+            collection: POST_BOOKING_EMAIL_DELIVERIES_SLUG,
+            id: delivery.id,
+            data: {
+              status: 'sent',
+              sentAt: new Date().toISOString(),
+            },
+            overrideAccess: true,
+          })
+          markedSent = true
+        } catch (error) {
+          if (attempt < 2) {
+            await new Promise((resolve) => setTimeout(resolve, 25 * (attempt + 1)))
+            continue
+          }
+          // Email already sent — keep the delivery row so idempotency still works.
+          req.payload.logger.error(
+            `[post-booking-email] Sent email but failed to mark delivery ${delivery.id} as sent: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          )
+        }
       }
     })()
   })

--- a/apps/atnd-me/src/lib/post-booking-email/send-post-booking-email.ts
+++ b/apps/atnd-me/src/lib/post-booking-email/send-post-booking-email.ts
@@ -2,7 +2,16 @@ import type { BasePayload } from 'payload'
 import { render } from '@react-email/components'
 import { PostBookingEmailLayout } from '@/emails/post-booking-email'
 import { renderPostBookingEmailBodyHtml } from './render-body-html'
-import type { PostBookingEmailConfig } from './types'
+
+/** Fields used by the shared renderer/sender (timing is handled by callers). */
+export type SendableEmailConfig = {
+  cc?: string | null
+  bcc?: string | null
+  replyTo?: string | null
+  emailFrom?: string | null
+  subject?: string | null
+  message?: unknown
+}
 
 function userEmailFromBookingUser(user: unknown): string | null {
   if (user && typeof user === 'object' && 'email' in user) {
@@ -31,7 +40,7 @@ export async function sendPostBookingEmail({
 }: {
   payload: BasePayload
   user: unknown
-  config: PostBookingEmailConfig
+  config: SendableEmailConfig
 }): Promise<void> {
   const to = userEmailFromBookingUser(user)
   if (!to) {

--- a/apps/atnd-me/src/lib/stripe-connect/bookingFee.ts
+++ b/apps/atnd-me/src/lib/stripe-connect/bookingFee.ts
@@ -4,13 +4,19 @@
 import type { Payload } from 'payload'
 
 /** Product types that map to fee-percent fields in platform-fees global. */
-export type BookingFeeProductType = 'drop-in' | 'class-pass' | 'subscription' | 'gift-voucher'
+export type BookingFeeProductType =
+  | 'drop-in'
+  | 'class-pass'
+  | 'course'
+  | 'subscription'
+  | 'gift-voucher'
 
 /** Shape of platform-fees global (defaults + overrides + bounds). */
 type PlatformFeesGlobal = {
   defaults?: {
     dropInPercent?: number
     classPassPercent?: number
+    coursePercent?: number
     subscriptionPercent?: number
     giftVoucherPercent?: number
   }
@@ -18,6 +24,7 @@ type PlatformFeesGlobal = {
     tenant?: number | { id: number }
     dropInPercent?: number | null
     classPassPercent?: number | null
+    coursePercent?: number | null
     subscriptionPercent?: number | null
     giftVoucherPercent?: number | null
   }>
@@ -30,6 +37,7 @@ type PlatformFeesGlobal = {
 const PRODUCT_FIELD_MAP: Record<BookingFeeProductType, keyof NonNullable<PlatformFeesGlobal['defaults']>> = {
   'drop-in': 'dropInPercent',
   'class-pass': 'classPassPercent',
+  course: 'coursePercent',
   subscription: 'subscriptionPercent',
   'gift-voucher': 'giftVoucherPercent',
 }
@@ -37,6 +45,7 @@ const PRODUCT_FIELD_MAP: Record<BookingFeeProductType, keyof NonNullable<Platfor
 const DEFAULT_PERCENTS: Record<BookingFeeProductType, number> = {
   'drop-in': 2,
   'class-pass': 3,
+  course: 3,
   subscription: 4,
   'gift-voucher': 3,
 }

--- a/apps/atnd-me/src/lib/stripe-connect/webhook/assign-course-enrollment-from-purchase.ts
+++ b/apps/atnd-me/src/lib/stripe-connect/webhook/assign-course-enrollment-from-purchase.ts
@@ -1,0 +1,139 @@
+/**
+ * Assign a course enrollment after a successful course_purchase Checkout / PaymentIntent.
+ */
+import type { Payload } from 'payload'
+import { buildCourseEnrollmentFromPurchase } from '@repo/bookings-payments'
+
+export type AssignCourseEnrollmentFromPurchaseResult =
+  | { assigned: true; enrollmentId: number | string }
+  | { assigned: false; reason: string }
+
+function parsePositiveInt(raw: unknown): number | null {
+  if (typeof raw === 'number' && Number.isFinite(raw) && raw > 0) {
+    return Math.floor(raw)
+  }
+  if (typeof raw === 'string' && raw.trim()) {
+    const n = Number(raw)
+    if (Number.isFinite(n) && n > 0) return Math.floor(n)
+  }
+  return null
+}
+
+export async function assignCourseEnrollmentFromPurchase(params: {
+  payload: Payload
+  tenantId: number
+  metadata: Record<string, string | undefined>
+  transactionId: string
+  tenantContext?: { tenant: number } | null
+  purchasedAt?: Date
+}): Promise<AssignCourseEnrollmentFromPurchaseResult> {
+  const { payload, tenantId, metadata: meta, transactionId, tenantContext } = params
+  const purchasedAt = params.purchasedAt ?? new Date()
+
+  if (meta.type !== 'course_purchase') {
+    return { assigned: false, reason: 'not_course_purchase' }
+  }
+
+  const userId = parsePositiveInt(meta.userId)
+  const courseId = parsePositiveInt(meta.courseId)
+  if (userId == null || courseId == null) {
+    payload.logger?.error?.(
+      `course_purchase: missing userId/courseId for transaction ${transactionId}`,
+    )
+    return { assigned: false, reason: 'missing_metadata' }
+  }
+
+  const existing = await payload.find({
+    collection: 'course-enrollments' as import('payload').CollectionSlug,
+    where: {
+      and: [
+        { tenant: { equals: tenantId } },
+        { transactionId: { equals: transactionId } },
+      ],
+    },
+    limit: 1,
+    depth: 0,
+    overrideAccess: true,
+  })
+
+  if (existing.docs[0]) {
+    return { assigned: true, enrollmentId: existing.docs[0].id as number | string }
+  }
+
+  const course = (await payload
+    .findByID({
+      collection: 'courses' as import('payload').CollectionSlug,
+      id: courseId,
+      depth: 0,
+      overrideAccess: true,
+      ...(tenantContext ? { context: tenantContext } : {}),
+    })
+    .catch(() => null)) as {
+    startDate?: string | null
+    endDate?: string | null
+    durationLength?: number | null
+    durationUnit?: 'days' | 'weeks' | null
+    status?: string | null
+    maxEnrollments?: number | null
+  } | null
+
+  if (!course) {
+    return { assigned: false, reason: 'course_not_found' }
+  }
+  if (course.status === 'archived' || course.status === 'closed' || course.status === 'draft') {
+    return { assigned: false, reason: 'course_not_open' }
+  }
+
+  if (typeof course.maxEnrollments === 'number' && course.maxEnrollments >= 1) {
+    const activeCount = await payload.find({
+      collection: 'course-enrollments' as import('payload').CollectionSlug,
+      where: {
+        and: [
+          { course: { equals: courseId } },
+          { tenant: { equals: tenantId } },
+          { status: { equals: 'active' } },
+        ],
+      },
+      limit: 0,
+      depth: 0,
+      overrideAccess: true,
+    })
+    if ((activeCount.totalDocs ?? 0) >= course.maxEnrollments) {
+      return { assigned: false, reason: 'sold_out' }
+    }
+  }
+
+  let enrollmentData
+  try {
+    enrollmentData = buildCourseEnrollmentFromPurchase({
+      userId,
+      courseId,
+      tenantId,
+      purchasedAt,
+      transactionId,
+      course: {
+        startDate: course.startDate,
+        endDate: course.endDate,
+        durationLength: course.durationLength,
+        durationUnit: course.durationUnit,
+      },
+    })
+  } catch (err) {
+    payload.logger?.error?.(
+      `course_purchase: invalid duration for course ${courseId}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    )
+    return { assigned: false, reason: 'invalid_course_duration' }
+  }
+
+  const created = await payload.create({
+    collection: 'course-enrollments' as import('payload').CollectionSlug,
+    draft: false,
+    data: enrollmentData as Record<string, unknown>,
+    overrideAccess: true,
+    ...(tenantContext ? { context: tenantContext } : {}),
+  })
+
+  return { assigned: true, enrollmentId: created.id as number | string }
+}

--- a/apps/atnd-me/src/lib/stripe-connect/webhook/index.ts
+++ b/apps/atnd-me/src/lib/stripe-connect/webhook/index.ts
@@ -16,3 +16,5 @@ export {
 } from './confirm-bookings'
 export { assignClassPassFromPurchase } from './assign-class-pass-from-purchase'
 export type { AssignClassPassFromPurchaseResult } from './assign-class-pass-from-purchase'
+export { assignCourseEnrollmentFromPurchase } from './assign-course-enrollment-from-purchase'
+export type { AssignCourseEnrollmentFromPurchaseResult } from './assign-course-enrollment-from-purchase'

--- a/apps/atnd-me/src/migrations/20260729_000003_courses_and_enrollments.ts
+++ b/apps/atnd-me/src/migrations/20260729_000003_courses_and_enrollments.ts
@@ -1,0 +1,175 @@
+import { MigrateDownArgs, MigrateUpArgs, sql } from '@payloadcms/db-postgres'
+
+/**
+ * Courses feature: courses + course-enrollments tables, allowedCourses / allowedEventTypes rels,
+ * and bookings.course_enrollment_id_used.
+ */
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+    DO $$ BEGIN
+      CREATE TYPE "public"."enum_courses_status" AS ENUM('draft', 'open', 'closed', 'archived');
+    EXCEPTION
+      WHEN duplicate_object THEN NULL;
+    END $$;
+
+    DO $$ BEGIN
+      CREATE TYPE "public"."enum_courses_duration_unit" AS ENUM('days', 'weeks');
+    EXCEPTION
+      WHEN duplicate_object THEN NULL;
+    END $$;
+
+    DO $$ BEGIN
+      CREATE TYPE "public"."enum_course_enrollments_status" AS ENUM('active', 'cancelled', 'completed');
+    EXCEPTION
+      WHEN duplicate_object THEN NULL;
+    END $$;
+
+    CREATE TABLE IF NOT EXISTS "courses" (
+      "id" serial PRIMARY KEY NOT NULL,
+      "title" varchar NOT NULL,
+      "slug" varchar NOT NULL,
+      "about" varchar,
+      "start_date" timestamp(3) with time zone,
+      "end_date" timestamp(3) with time zone,
+      "duration_length" numeric,
+      "duration_unit" "enum_courses_duration_unit" DEFAULT 'weeks',
+      "max_enrollments" numeric,
+      "stripe_product_id" varchar,
+      "price_information_price" numeric,
+      "status" "enum_courses_status" DEFAULT 'draft' NOT NULL,
+      "tenant_id" integer,
+      "updated_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+      "created_at" timestamp(3) with time zone DEFAULT now() NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS "courses_rels" (
+      "id" serial PRIMARY KEY NOT NULL,
+      "order" integer,
+      "parent_id" integer NOT NULL,
+      "path" varchar NOT NULL,
+      "event_types_id" integer
+    );
+
+    CREATE TABLE IF NOT EXISTS "course_enrollments" (
+      "id" serial PRIMARY KEY NOT NULL,
+      "user_id" integer NOT NULL,
+      "course_id" integer NOT NULL,
+      "status" "enum_course_enrollments_status" DEFAULT 'active' NOT NULL,
+      "purchased_at" timestamp(3) with time zone NOT NULL,
+      "access_starts_at" timestamp(3) with time zone NOT NULL,
+      "access_ends_at" timestamp(3) with time zone NOT NULL,
+      "transaction_id" varchar,
+      "tenant_id" integer,
+      "updated_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+      "created_at" timestamp(3) with time zone DEFAULT now() NOT NULL
+    );
+  `)
+
+  await db.execute(sql`
+    DO $$ BEGIN
+      ALTER TABLE "courses"
+        ADD CONSTRAINT "courses_tenant_id_tenants_id_fk"
+        FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE set null ON UPDATE no action;
+    EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+    DO $$ BEGIN
+      ALTER TABLE "courses_rels"
+        ADD CONSTRAINT "courses_rels_parent_fk"
+        FOREIGN KEY ("parent_id") REFERENCES "public"."courses"("id") ON DELETE cascade ON UPDATE no action;
+    EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+    DO $$ BEGIN
+      ALTER TABLE "courses_rels"
+        ADD CONSTRAINT "courses_rels_event_types_fk"
+        FOREIGN KEY ("event_types_id") REFERENCES "public"."event_types"("id") ON DELETE cascade ON UPDATE no action;
+    EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+    DO $$ BEGIN
+      ALTER TABLE "course_enrollments"
+        ADD CONSTRAINT "course_enrollments_user_id_users_id_fk"
+        FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+    EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+    DO $$ BEGIN
+      ALTER TABLE "course_enrollments"
+        ADD CONSTRAINT "course_enrollments_course_id_courses_id_fk"
+        FOREIGN KEY ("course_id") REFERENCES "public"."courses"("id") ON DELETE cascade ON UPDATE no action;
+    EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+    DO $$ BEGIN
+      ALTER TABLE "course_enrollments"
+        ADD CONSTRAINT "course_enrollments_tenant_id_tenants_id_fk"
+        FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE set null ON UPDATE no action;
+    EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+  `)
+
+  await db.execute(sql`
+    CREATE INDEX IF NOT EXISTS "courses_slug_idx" ON "courses" USING btree ("slug");
+    CREATE INDEX IF NOT EXISTS "courses_tenant_idx" ON "courses" USING btree ("tenant_id");
+    CREATE INDEX IF NOT EXISTS "courses_updated_at_idx" ON "courses" USING btree ("updated_at");
+    CREATE INDEX IF NOT EXISTS "courses_created_at_idx" ON "courses" USING btree ("created_at");
+    CREATE INDEX IF NOT EXISTS "courses_rels_order_idx" ON "courses_rels" USING btree ("order");
+    CREATE INDEX IF NOT EXISTS "courses_rels_parent_idx" ON "courses_rels" USING btree ("parent_id");
+    CREATE INDEX IF NOT EXISTS "courses_rels_path_idx" ON "courses_rels" USING btree ("path");
+    CREATE INDEX IF NOT EXISTS "courses_rels_event_types_id_idx" ON "courses_rels" USING btree ("event_types_id");
+    CREATE INDEX IF NOT EXISTS "course_enrollments_user_idx" ON "course_enrollments" USING btree ("user_id");
+    CREATE INDEX IF NOT EXISTS "course_enrollments_course_idx" ON "course_enrollments" USING btree ("course_id");
+    CREATE INDEX IF NOT EXISTS "course_enrollments_tenant_idx" ON "course_enrollments" USING btree ("tenant_id");
+    CREATE INDEX IF NOT EXISTS "course_enrollments_updated_at_idx" ON "course_enrollments" USING btree ("updated_at");
+    CREATE INDEX IF NOT EXISTS "course_enrollments_created_at_idx" ON "course_enrollments" USING btree ("created_at");
+  `)
+
+  await db.execute(sql`
+    ALTER TABLE "event_types_rels" ADD COLUMN IF NOT EXISTS "courses_id" integer;
+    DO $$ BEGIN
+      ALTER TABLE "event_types_rels"
+        ADD CONSTRAINT "event_types_rels_courses_fk"
+        FOREIGN KEY ("courses_id") REFERENCES "public"."courses"("id") ON DELETE cascade ON UPDATE no action;
+    EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+    CREATE INDEX IF NOT EXISTS "event_types_rels_courses_id_idx" ON "event_types_rels" USING btree ("courses_id");
+
+    ALTER TABLE "bookings" ADD COLUMN IF NOT EXISTS "course_enrollment_id_used" integer;
+
+    ALTER TABLE "payload_locked_documents_rels" ADD COLUMN IF NOT EXISTS "courses_id" integer;
+    ALTER TABLE "payload_locked_documents_rels" ADD COLUMN IF NOT EXISTS "course_enrollments_id" integer;
+    DO $$ BEGIN
+      ALTER TABLE "payload_locked_documents_rels"
+        ADD CONSTRAINT "payload_locked_documents_rels_courses_fk"
+        FOREIGN KEY ("courses_id") REFERENCES "public"."courses"("id") ON DELETE cascade ON UPDATE no action;
+    EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+    DO $$ BEGIN
+      ALTER TABLE "payload_locked_documents_rels"
+        ADD CONSTRAINT "payload_locked_documents_rels_course_enrollments_fk"
+        FOREIGN KEY ("course_enrollments_id") REFERENCES "public"."course_enrollments"("id") ON DELETE cascade ON UPDATE no action;
+    EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+    CREATE INDEX IF NOT EXISTS "payload_locked_documents_rels_courses_id_idx"
+      ON "payload_locked_documents_rels" USING btree ("courses_id");
+    CREATE INDEX IF NOT EXISTS "payload_locked_documents_rels_course_enrollments_id_idx"
+      ON "payload_locked_documents_rels" USING btree ("course_enrollments_id");
+  `)
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+    ALTER TABLE "payload_locked_documents_rels" DROP CONSTRAINT IF EXISTS "payload_locked_documents_rels_course_enrollments_fk";
+    ALTER TABLE "payload_locked_documents_rels" DROP CONSTRAINT IF EXISTS "payload_locked_documents_rels_courses_fk";
+    DROP INDEX IF EXISTS "payload_locked_documents_rels_course_enrollments_id_idx";
+    DROP INDEX IF EXISTS "payload_locked_documents_rels_courses_id_idx";
+    ALTER TABLE "payload_locked_documents_rels" DROP COLUMN IF EXISTS "course_enrollments_id";
+    ALTER TABLE "payload_locked_documents_rels" DROP COLUMN IF EXISTS "courses_id";
+
+    ALTER TABLE "bookings" DROP COLUMN IF EXISTS "course_enrollment_id_used";
+
+    ALTER TABLE "event_types_rels" DROP CONSTRAINT IF EXISTS "event_types_rels_courses_fk";
+    DROP INDEX IF EXISTS "event_types_rels_courses_id_idx";
+    ALTER TABLE "event_types_rels" DROP COLUMN IF EXISTS "courses_id";
+
+    DROP TABLE IF EXISTS "course_enrollments" CASCADE;
+    DROP TABLE IF EXISTS "courses_rels" CASCADE;
+    DROP TABLE IF EXISTS "courses" CASCADE;
+
+    DROP TYPE IF EXISTS "public"."enum_course_enrollments_status";
+    DROP TYPE IF EXISTS "public"."enum_courses_duration_unit";
+    DROP TYPE IF EXISTS "public"."enum_courses_status";
+  `)
+}

--- a/apps/atnd-me/src/migrations/20260729_000004_course_emails_and_deliveries.ts
+++ b/apps/atnd-me/src/migrations/20260729_000004_course_emails_and_deliveries.ts
@@ -1,0 +1,170 @@
+import { MigrateDownArgs, MigrateUpArgs, sql } from '@payloadcms/db-postgres'
+
+/**
+ * Course emails array on courses + course-email-deliveries + sendCourseEmail job enum.
+ */
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+    DO $$ BEGIN
+      CREATE TYPE "public"."enum_courses_course_emails_send_timing" AS ENUM(
+        'after_purchase',
+        'one_week_before_start',
+        'one_day_before_start',
+        'one_day_after_start',
+        'one_day_before_end',
+        'one_day_after_end'
+      );
+    EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+    CREATE TABLE IF NOT EXISTS "courses_course_emails" (
+      "_order" integer NOT NULL,
+      "_parent_id" integer NOT NULL,
+      "id" varchar PRIMARY KEY NOT NULL,
+      "cc" varchar,
+      "bcc" varchar,
+      "reply_to" varchar,
+      "email_from" varchar,
+      "subject" varchar NOT NULL,
+      "message" jsonb,
+      "send_timing" "enum_courses_course_emails_send_timing" DEFAULT 'after_purchase' NOT NULL
+    );
+
+    DO $$ BEGIN
+      ALTER TABLE "courses_course_emails"
+        ADD CONSTRAINT "courses_course_emails_parent_id_fk"
+        FOREIGN KEY ("_parent_id") REFERENCES "public"."courses"("id") ON DELETE cascade ON UPDATE no action;
+    EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+    CREATE INDEX IF NOT EXISTS "courses_course_emails_order_idx"
+      ON "courses_course_emails" USING btree ("_order");
+    CREATE INDEX IF NOT EXISTS "courses_course_emails_parent_id_idx"
+      ON "courses_course_emails" USING btree ("_parent_id");
+
+    DO $$ BEGIN
+      CREATE TYPE "public"."enum_course_email_deliveries_send_timing" AS ENUM(
+        'after_purchase',
+        'one_week_before_start',
+        'one_day_before_start',
+        'one_day_after_start',
+        'one_day_before_end',
+        'one_day_after_end'
+      );
+    EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+    DO $$ BEGIN
+      CREATE TYPE "public"."enum_course_email_deliveries_status" AS ENUM(
+        'scheduled',
+        'sent',
+        'cancelled'
+      );
+    EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+    CREATE TABLE IF NOT EXISTS "course_email_deliveries" (
+      "id" serial PRIMARY KEY NOT NULL,
+      "tenant_id" integer,
+      "user_id" integer NOT NULL,
+      "enrollment_id" integer NOT NULL,
+      "course_id" integer NOT NULL,
+      "email_config_id" varchar NOT NULL,
+      "send_timing" "enum_course_email_deliveries_send_timing" NOT NULL,
+      "status" "enum_course_email_deliveries_status" DEFAULT 'scheduled' NOT NULL,
+      "payload_job_id" numeric,
+      "scheduled_for" timestamp(3) with time zone,
+      "sent_at" timestamp(3) with time zone,
+      "updated_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+      "created_at" timestamp(3) with time zone DEFAULT now() NOT NULL
+    );
+
+    DO $$ BEGIN
+      ALTER TABLE "course_email_deliveries"
+        ADD CONSTRAINT "course_email_deliveries_tenant_id_tenants_id_fk"
+        FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE set null ON UPDATE no action;
+    EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+    DO $$ BEGIN
+      ALTER TABLE "course_email_deliveries"
+        ADD CONSTRAINT "course_email_deliveries_user_id_users_id_fk"
+        FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;
+    EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+    DO $$ BEGIN
+      ALTER TABLE "course_email_deliveries"
+        ADD CONSTRAINT "course_email_deliveries_enrollment_id_course_enrollments_id_fk"
+        FOREIGN KEY ("enrollment_id") REFERENCES "public"."course_enrollments"("id") ON DELETE cascade ON UPDATE no action;
+    EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+    DO $$ BEGIN
+      ALTER TABLE "course_email_deliveries"
+        ADD CONSTRAINT "course_email_deliveries_course_id_courses_id_fk"
+        FOREIGN KEY ("course_id") REFERENCES "public"."courses"("id") ON DELETE cascade ON UPDATE no action;
+    EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+    CREATE UNIQUE INDEX IF NOT EXISTS "course_email_deliveries_tenant_user_enrollment_course_email_c_idx"
+      ON "course_email_deliveries" USING btree (
+        "tenant_id",
+        "user_id",
+        "enrollment_id",
+        "course_id",
+        "email_config_id"
+      );
+
+    CREATE INDEX IF NOT EXISTS "course_email_deliveries_user_idx"
+      ON "course_email_deliveries" USING btree ("user_id");
+    CREATE INDEX IF NOT EXISTS "course_email_deliveries_enrollment_idx"
+      ON "course_email_deliveries" USING btree ("enrollment_id");
+    CREATE INDEX IF NOT EXISTS "course_email_deliveries_course_idx"
+      ON "course_email_deliveries" USING btree ("course_id");
+    CREATE INDEX IF NOT EXISTS "course_email_deliveries_tenant_idx"
+      ON "course_email_deliveries" USING btree ("tenant_id");
+
+    ALTER TABLE "payload_locked_documents_rels"
+      ADD COLUMN IF NOT EXISTS "course_email_deliveries_id" integer;
+    DO $$ BEGIN
+      ALTER TABLE "payload_locked_documents_rels"
+        ADD CONSTRAINT "payload_locked_documents_rels_course_email_deliveries_fk"
+        FOREIGN KEY ("course_email_deliveries_id")
+        REFERENCES "public"."course_email_deliveries"("id") ON DELETE cascade ON UPDATE no action;
+    EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+    CREATE INDEX IF NOT EXISTS "payload_locked_documents_rels_course_email_deliveries_id_idx"
+      ON "payload_locked_documents_rels" USING btree ("course_email_deliveries_id");
+  `)
+
+  await db.execute(sql`
+    DO $$ BEGIN
+      IF NOT EXISTS (
+        SELECT 1 FROM pg_enum
+        WHERE enumlabel = 'sendCourseEmail'
+          AND enumtypid = 'public.enum_payload_jobs_task_slug'::regtype
+      ) THEN
+        ALTER TYPE "public"."enum_payload_jobs_task_slug" ADD VALUE 'sendCourseEmail';
+      END IF;
+    END $$;
+
+    DO $$ BEGIN
+      IF NOT EXISTS (
+        SELECT 1 FROM pg_enum
+        WHERE enumlabel = 'sendCourseEmail'
+          AND enumtypid = 'public.enum_payload_jobs_log_task_slug'::regtype
+      ) THEN
+        ALTER TYPE "public"."enum_payload_jobs_log_task_slug" ADD VALUE 'sendCourseEmail';
+      END IF;
+    END $$;
+  `)
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+    ALTER TABLE "payload_locked_documents_rels"
+      DROP CONSTRAINT IF EXISTS "payload_locked_documents_rels_course_email_deliveries_fk";
+    DROP INDEX IF EXISTS "payload_locked_documents_rels_course_email_deliveries_id_idx";
+    ALTER TABLE "payload_locked_documents_rels"
+      DROP COLUMN IF EXISTS "course_email_deliveries_id";
+
+    DROP TABLE IF EXISTS "course_email_deliveries" CASCADE;
+    DROP TABLE IF EXISTS "courses_course_emails" CASCADE;
+
+    DROP TYPE IF EXISTS "public"."enum_course_email_deliveries_status";
+    DROP TYPE IF EXISTS "public"."enum_course_email_deliveries_send_timing";
+    DROP TYPE IF EXISTS "public"."enum_courses_course_emails_send_timing";
+  `)
+}

--- a/apps/atnd-me/src/migrations/20260729_000005_platform_fees_course_percent.ts
+++ b/apps/atnd-me/src/migrations/20260729_000005_platform_fees_course_percent.ts
@@ -1,0 +1,24 @@
+import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres'
+
+/**
+ * Add course platform fee percent to platform-fees defaults and overrides.
+ */
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+    ALTER TABLE "platform_fees"
+      ADD COLUMN IF NOT EXISTS "defaults_course_percent" numeric DEFAULT 3 NOT NULL;
+
+    ALTER TABLE "platform_fees_overrides"
+      ADD COLUMN IF NOT EXISTS "course_percent" numeric;
+  `)
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+    ALTER TABLE "platform_fees_overrides"
+      DROP COLUMN IF EXISTS "course_percent";
+
+    ALTER TABLE "platform_fees"
+      DROP COLUMN IF EXISTS "defaults_course_percent";
+  `)
+}

--- a/apps/atnd-me/src/migrations/20260729_000006_backfill_timeslots_admin_title.ts
+++ b/apps/atnd-me/src/migrations/20260729_000006_backfill_timeslots_admin_title.ts
@@ -8,23 +8,31 @@ import { MigrateDownArgs, MigrateUpArgs, sql } from '@payloadcms/db-postgres'
  * Format matches `formatTimeslotAdminTitle` (Europe/Dublin default).
  */
 export async function up({ db }: MigrateUpArgs): Promise<void> {
+  // Join via derived table: Postgres forbids referencing the UPDATE target
+  // alias in a FROM/JOIN ON clause (`invalid reference to FROM-clause entry`).
   await db.execute(sql`
     UPDATE "timeslots" AS ts
-    SET "admin_title" = (
-      initcap(to_char(ts.start_time AT TIME ZONE COALESCE(NULLIF(l.time_zone, ''), NULLIF(t.time_zone, ''), 'Europe/Dublin'), 'Dy'))
-      || ' '
-      || to_char(ts.start_time AT TIME ZONE COALESCE(NULLIF(l.time_zone, ''), NULLIF(t.time_zone, ''), 'Europe/Dublin'), 'FMDD Mon YYYY')
-      || ' · '
-      || trim(to_char(ts.start_time AT TIME ZONE COALESCE(NULLIF(l.time_zone, ''), NULLIF(t.time_zone, ''), 'Europe/Dublin'), 'FMHH12:MI AM'))
-      || ' – '
-      || trim(to_char(ts.end_time AT TIME ZONE COALESCE(NULLIF(l.time_zone, ''), NULLIF(t.time_zone, ''), 'Europe/Dublin'), 'FMHH12:MI AM'))
-    )
-    FROM "tenants" AS t
-    LEFT JOIN "locations" AS l ON l.id = ts.branch_id
-    WHERE t.id = ts.tenant_id
-      AND (ts.admin_title IS NULL OR btrim(ts.admin_title) = '')
-      AND ts.start_time IS NOT NULL
-      AND ts.end_time IS NOT NULL;
+    SET "admin_title" = src."admin_title"
+    FROM (
+      SELECT
+        ts2.id,
+        (
+          initcap(to_char(ts2.start_time AT TIME ZONE COALESCE(NULLIF(l.time_zone, ''), NULLIF(t.time_zone, ''), 'Europe/Dublin'), 'Dy'))
+          || ' '
+          || to_char(ts2.start_time AT TIME ZONE COALESCE(NULLIF(l.time_zone, ''), NULLIF(t.time_zone, ''), 'Europe/Dublin'), 'FMDD Mon YYYY')
+          || ' · '
+          || trim(to_char(ts2.start_time AT TIME ZONE COALESCE(NULLIF(l.time_zone, ''), NULLIF(t.time_zone, ''), 'Europe/Dublin'), 'FMHH12:MI AM'))
+          || ' – '
+          || trim(to_char(ts2.end_time AT TIME ZONE COALESCE(NULLIF(l.time_zone, ''), NULLIF(t.time_zone, ''), 'Europe/Dublin'), 'FMHH12:MI AM'))
+        ) AS "admin_title"
+      FROM "timeslots" AS ts2
+      INNER JOIN "tenants" AS t ON t.id = ts2.tenant_id
+      LEFT JOIN "locations" AS l ON l.id = ts2.branch_id
+      WHERE (ts2.admin_title IS NULL OR btrim(ts2.admin_title) = '')
+        AND ts2.start_time IS NOT NULL
+        AND ts2.end_time IS NOT NULL
+    ) AS src
+    WHERE ts.id = src.id
   `)
 
   // Timeslots without a tenant still need a label (default Europe/Dublin).
@@ -41,11 +49,10 @@ export async function up({ db }: MigrateUpArgs): Promise<void> {
     )
     WHERE (ts.admin_title IS NULL OR btrim(ts.admin_title) = '')
       AND ts.start_time IS NOT NULL
-      AND ts.end_time IS NOT NULL;
+      AND ts.end_time IS NOT NULL
   `)
 }
 
-export async function down({ db }: MigrateDownArgs): Promise<void> {
+export async function down(_args: MigrateDownArgs): Promise<void> {
   // Non-destructive: leave titles in place (they remain valid labels).
-  await db.execute(sql`SELECT 1`)
 }

--- a/apps/atnd-me/src/migrations/20260729_000006_backfill_timeslots_admin_title.ts
+++ b/apps/atnd-me/src/migrations/20260729_000006_backfill_timeslots_admin_title.ts
@@ -1,0 +1,51 @@
+import { MigrateDownArgs, MigrateUpArgs, sql } from '@payloadcms/db-postgres'
+
+/**
+ * Backfill denormalized `adminTitle` for existing timeslots.
+ *
+ * Relationship pickers use the stored useAsTitle value and do not run afterRead
+ * fallbacks when the title field is null, so legacy rows show "Untitled - ID: …".
+ * Format matches `formatTimeslotAdminTitle` (Europe/Dublin default).
+ */
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+    UPDATE "timeslots" AS ts
+    SET "admin_title" = (
+      initcap(to_char(ts.start_time AT TIME ZONE COALESCE(NULLIF(l.time_zone, ''), NULLIF(t.time_zone, ''), 'Europe/Dublin'), 'Dy'))
+      || ' '
+      || to_char(ts.start_time AT TIME ZONE COALESCE(NULLIF(l.time_zone, ''), NULLIF(t.time_zone, ''), 'Europe/Dublin'), 'FMDD Mon YYYY')
+      || ' · '
+      || trim(to_char(ts.start_time AT TIME ZONE COALESCE(NULLIF(l.time_zone, ''), NULLIF(t.time_zone, ''), 'Europe/Dublin'), 'FMHH12:MI AM'))
+      || ' – '
+      || trim(to_char(ts.end_time AT TIME ZONE COALESCE(NULLIF(l.time_zone, ''), NULLIF(t.time_zone, ''), 'Europe/Dublin'), 'FMHH12:MI AM'))
+    )
+    FROM "tenants" AS t
+    LEFT JOIN "locations" AS l ON l.id = ts.branch_id
+    WHERE t.id = ts.tenant_id
+      AND (ts.admin_title IS NULL OR btrim(ts.admin_title) = '')
+      AND ts.start_time IS NOT NULL
+      AND ts.end_time IS NOT NULL;
+  `)
+
+  // Timeslots without a tenant still need a label (default Europe/Dublin).
+  await db.execute(sql`
+    UPDATE "timeslots" AS ts
+    SET "admin_title" = (
+      initcap(to_char(ts.start_time AT TIME ZONE 'Europe/Dublin', 'Dy'))
+      || ' '
+      || to_char(ts.start_time AT TIME ZONE 'Europe/Dublin', 'FMDD Mon YYYY')
+      || ' · '
+      || trim(to_char(ts.start_time AT TIME ZONE 'Europe/Dublin', 'FMHH12:MI AM'))
+      || ' – '
+      || trim(to_char(ts.end_time AT TIME ZONE 'Europe/Dublin', 'FMHH12:MI AM'))
+    )
+    WHERE (ts.admin_title IS NULL OR btrim(ts.admin_title) = '')
+      AND ts.start_time IS NOT NULL
+      AND ts.end_time IS NOT NULL;
+  `)
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  // Non-destructive: leave titles in place (they remain valid labels).
+  await db.execute(sql`SELECT 1`)
+}

--- a/apps/atnd-me/src/migrations/20260729_000007_checkout_hold_session_released.ts
+++ b/apps/atnd-me/src/migrations/20260729_000007_checkout_hold_session_released.ts
@@ -1,0 +1,27 @@
+import { MigrateDownArgs, MigrateUpArgs, sql } from '@payloadcms/db-postgres'
+
+/**
+ * Add checkoutSessionId + allow status=released so abandon/release can block
+ * late in-flight upserts from recreating capacity holds after page exit.
+ */
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+    ALTER TABLE "booking_checkout_holds"
+      ADD COLUMN IF NOT EXISTS "checkout_session_id" varchar;
+  `)
+
+  await db.execute(sql`
+    CREATE INDEX IF NOT EXISTS "booking_checkout_holds_checkout_session_id_idx"
+      ON "booking_checkout_holds" ("checkout_session_id");
+  `)
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+    DROP INDEX IF EXISTS "booking_checkout_holds_checkout_session_id_idx";
+  `)
+  await db.execute(sql`
+    ALTER TABLE "booking_checkout_holds"
+      DROP COLUMN IF EXISTS "checkout_session_id";
+  `)
+}

--- a/apps/atnd-me/src/migrations/20260730_000001_courses_access_window_mode.ts
+++ b/apps/atnd-me/src/migrations/20260730_000001_courses_access_window_mode.ts
@@ -1,0 +1,57 @@
+import { MigrateDownArgs, MigrateUpArgs, sql } from '@payloadcms/db-postgres'
+
+/**
+ * Admin either/or for course access: fixed dates vs duration from purchase.
+ * Backfills access_window_mode from existing start/end or duration fields.
+ */
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+    DO $$ BEGIN
+      CREATE TYPE "public"."enum_courses_access_window_mode" AS ENUM('fixed', 'duration');
+    EXCEPTION
+      WHEN duplicate_object THEN NULL;
+    END $$;
+  `)
+
+  await db.execute(sql`
+    ALTER TABLE "courses"
+      ADD COLUMN IF NOT EXISTS "access_window_mode" "enum_courses_access_window_mode";
+  `)
+
+  await db.execute(sql`
+    UPDATE "courses"
+    SET "access_window_mode" = 'fixed'
+    WHERE "access_window_mode" IS NULL
+      AND "start_date" IS NOT NULL
+      AND "end_date" IS NOT NULL;
+  `)
+
+  await db.execute(sql`
+    UPDATE "courses"
+    SET "access_window_mode" = 'duration'
+    WHERE "access_window_mode" IS NULL
+      AND "duration_length" IS NOT NULL;
+  `)
+
+  await db.execute(sql`
+    UPDATE "courses"
+    SET "access_window_mode" = 'duration'
+    WHERE "access_window_mode" IS NULL;
+  `)
+
+  await db.execute(sql`
+    ALTER TABLE "courses"
+      ALTER COLUMN "access_window_mode" SET NOT NULL;
+  `)
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+    ALTER TABLE "courses"
+      DROP COLUMN IF EXISTS "access_window_mode";
+  `)
+
+  await db.execute(sql`
+    DROP TYPE IF EXISTS "public"."enum_courses_access_window_mode";
+  `)
+}

--- a/apps/atnd-me/src/migrations/20260730_000002_courses_cover_image.ts
+++ b/apps/atnd-me/src/migrations/20260730_000002_courses_cover_image.ts
@@ -1,0 +1,37 @@
+import { MigrateDownArgs, MigrateUpArgs, sql } from '@payloadcms/db-postgres'
+
+/**
+ * Optional cover image for courses (listing + detail hero).
+ */
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+    ALTER TABLE "courses"
+      ADD COLUMN IF NOT EXISTS "cover_image_id" integer;
+  `)
+
+  await db.execute(sql`
+    DO $$ BEGIN
+      IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'courses_cover_image_id_media_id_fk'
+      ) THEN
+        ALTER TABLE "courses"
+          ADD CONSTRAINT "courses_cover_image_id_media_id_fk"
+          FOREIGN KEY ("cover_image_id") REFERENCES "public"."media"("id")
+          ON DELETE set null ON UPDATE no action;
+      END IF;
+    END $$;
+  `)
+
+  await db.execute(sql`
+    CREATE INDEX IF NOT EXISTS "courses_cover_image_idx"
+      ON "courses" USING btree ("cover_image_id");
+  `)
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+    ALTER TABLE "courses" DROP CONSTRAINT IF EXISTS "courses_cover_image_id_media_id_fk";
+    DROP INDEX IF EXISTS "courses_cover_image_idx";
+    ALTER TABLE "courses" DROP COLUMN IF EXISTS "cover_image_id";
+  `)
+}

--- a/apps/atnd-me/src/migrations/20260730_000003_courses_about_richtext.ts
+++ b/apps/atnd-me/src/migrations/20260730_000003_courses_about_richtext.ts
@@ -1,0 +1,94 @@
+import { MigrateDownArgs, MigrateUpArgs, sql } from '@payloadcms/db-postgres'
+
+/**
+ * Convert courses.about from plain varchar to Lexical richText jsonb.
+ * Preserves existing plain-text values as a single paragraph.
+ */
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+    DO $$
+    BEGIN
+      IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'courses'
+          AND column_name = 'about'
+          AND data_type <> 'jsonb'
+      ) THEN
+        ALTER TABLE "courses" ADD COLUMN "about_richtext" jsonb;
+
+        UPDATE "courses"
+        SET "about_richtext" = CASE
+          WHEN "about" IS NULL OR btrim("about") = '' THEN NULL
+          ELSE jsonb_build_object(
+            'root', jsonb_build_object(
+              'type', 'root',
+              'format', '',
+              'indent', 0,
+              'version', 1,
+              'direction', 'ltr',
+              'children', jsonb_build_array(
+                jsonb_build_object(
+                  'type', 'paragraph',
+                  'format', '',
+                  'indent', 0,
+                  'version', 1,
+                  'direction', 'ltr',
+                  'textFormat', 0,
+                  'children', jsonb_build_array(
+                    jsonb_build_object(
+                      'type', 'text',
+                      'detail', 0,
+                      'format', 0,
+                      'mode', 'normal',
+                      'style', '',
+                      'text', "about",
+                      'version', 1
+                    )
+                  )
+                )
+              )
+            )
+          )
+        END;
+
+        ALTER TABLE "courses" DROP COLUMN "about";
+        ALTER TABLE "courses" RENAME COLUMN "about_richtext" TO "about";
+      END IF;
+    END $$;
+  `)
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+    DO $$
+    BEGIN
+      IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'courses'
+          AND column_name = 'about'
+          AND data_type = 'jsonb'
+      ) THEN
+        ALTER TABLE "courses" ADD COLUMN "about_text" varchar;
+
+        UPDATE "courses"
+        SET "about_text" = NULLIF(
+          btrim(
+            coalesce(
+              (
+                SELECT string_agg(node->>'text', ' ')
+                FROM jsonb_path_query("about", '$.root.children[*].children[*].text') AS node
+              ),
+              ''
+            )
+          ),
+          ''
+        );
+
+        ALTER TABLE "courses" DROP COLUMN "about";
+        ALTER TABLE "courses" RENAME COLUMN "about_text" TO "about";
+      END IF;
+    END $$;
+  `)
+}

--- a/apps/atnd-me/src/migrations/index.ts
+++ b/apps/atnd-me/src/migrations/index.ts
@@ -160,6 +160,9 @@ import * as migration_20260729_000003_courses_and_enrollments from './20260729_0
 import * as migration_20260729_000004_course_emails_and_deliveries from './20260729_000004_course_emails_and_deliveries';
 import * as migration_20260729_000005_platform_fees_course_percent from './20260729_000005_platform_fees_course_percent';
 import * as migration_20260729_000006_backfill_timeslots_admin_title from './20260729_000006_backfill_timeslots_admin_title';
+import * as migration_20260730_000001_courses_access_window_mode from './20260730_000001_courses_access_window_mode';
+import * as migration_20260730_000002_courses_cover_image from './20260730_000002_courses_cover_image';
+import * as migration_20260730_000003_courses_about_richtext from './20260730_000003_courses_about_richtext';
 import * as migration_20260721_000001_marketing_hero_show_username_claim from './20260721_000001_marketing_hero_show_username_claim';
 import * as migration_20260721_000002_hero_sched_display_heading from './20260721_000002_hero_sched_display_heading';
 import * as migration_20260721_000003_tenants_onboarding_site_viewed from './20260721_000003_tenants_onboarding_site_viewed';
@@ -1019,5 +1022,20 @@ export const migrations = [
     up: migration_20260729_000006_backfill_timeslots_admin_title.up,
     down: migration_20260729_000006_backfill_timeslots_admin_title.down,
     name: '20260729_000006_backfill_timeslots_admin_title',
+  },
+  {
+    up: migration_20260730_000001_courses_access_window_mode.up,
+    down: migration_20260730_000001_courses_access_window_mode.down,
+    name: '20260730_000001_courses_access_window_mode',
+  },
+  {
+    up: migration_20260730_000002_courses_cover_image.up,
+    down: migration_20260730_000002_courses_cover_image.down,
+    name: '20260730_000002_courses_cover_image',
+  },
+  {
+    up: migration_20260730_000003_courses_about_richtext.up,
+    down: migration_20260730_000003_courses_about_richtext.down,
+    name: '20260730_000003_courses_about_richtext',
   },
 ];

--- a/apps/atnd-me/src/migrations/index.ts
+++ b/apps/atnd-me/src/migrations/index.ts
@@ -156,6 +156,10 @@ import * as migration_20260728_000007_event_block_marketing_fields from './20260
 import * as migration_20260728_000008_event_block_event_type_field from './20260728_000008_event_block_event_type_field';
 import * as migration_20260729_000001_timeslots_admin_title from './20260729_000001_timeslots_admin_title';
 import * as migration_20260729_000002_event_block_timeslot_date from './20260729_000002_event_block_timeslot_date';
+import * as migration_20260729_000003_courses_and_enrollments from './20260729_000003_courses_and_enrollments';
+import * as migration_20260729_000004_course_emails_and_deliveries from './20260729_000004_course_emails_and_deliveries';
+import * as migration_20260729_000005_platform_fees_course_percent from './20260729_000005_platform_fees_course_percent';
+import * as migration_20260729_000006_backfill_timeslots_admin_title from './20260729_000006_backfill_timeslots_admin_title';
 import * as migration_20260721_000001_marketing_hero_show_username_claim from './20260721_000001_marketing_hero_show_username_claim';
 import * as migration_20260721_000002_hero_sched_display_heading from './20260721_000002_hero_sched_display_heading';
 import * as migration_20260721_000003_tenants_onboarding_site_viewed from './20260721_000003_tenants_onboarding_site_viewed';
@@ -995,5 +999,25 @@ export const migrations = [
     up: migration_20260729_000002_event_block_timeslot_date.up,
     down: migration_20260729_000002_event_block_timeslot_date.down,
     name: '20260729_000002_event_block_timeslot_date',
+  },
+  {
+    up: migration_20260729_000003_courses_and_enrollments.up,
+    down: migration_20260729_000003_courses_and_enrollments.down,
+    name: '20260729_000003_courses_and_enrollments',
+  },
+  {
+    up: migration_20260729_000004_course_emails_and_deliveries.up,
+    down: migration_20260729_000004_course_emails_and_deliveries.down,
+    name: '20260729_000004_course_emails_and_deliveries',
+  },
+  {
+    up: migration_20260729_000005_platform_fees_course_percent.up,
+    down: migration_20260729_000005_platform_fees_course_percent.down,
+    name: '20260729_000005_platform_fees_course_percent',
+  },
+  {
+    up: migration_20260729_000006_backfill_timeslots_admin_title.up,
+    down: migration_20260729_000006_backfill_timeslots_admin_title.down,
+    name: '20260729_000006_backfill_timeslots_admin_title',
   },
 ];

--- a/apps/atnd-me/src/migrations/index.ts
+++ b/apps/atnd-me/src/migrations/index.ts
@@ -160,6 +160,7 @@ import * as migration_20260729_000003_courses_and_enrollments from './20260729_0
 import * as migration_20260729_000004_course_emails_and_deliveries from './20260729_000004_course_emails_and_deliveries';
 import * as migration_20260729_000005_platform_fees_course_percent from './20260729_000005_platform_fees_course_percent';
 import * as migration_20260729_000006_backfill_timeslots_admin_title from './20260729_000006_backfill_timeslots_admin_title';
+import * as migration_20260729_000007_checkout_hold_session_released from './20260729_000007_checkout_hold_session_released';
 import * as migration_20260730_000001_courses_access_window_mode from './20260730_000001_courses_access_window_mode';
 import * as migration_20260730_000002_courses_cover_image from './20260730_000002_courses_cover_image';
 import * as migration_20260730_000003_courses_about_richtext from './20260730_000003_courses_about_richtext';
@@ -1022,6 +1023,11 @@ export const migrations = [
     up: migration_20260729_000006_backfill_timeslots_admin_title.up,
     down: migration_20260729_000006_backfill_timeslots_admin_title.down,
     name: '20260729_000006_backfill_timeslots_admin_title',
+  },
+  {
+    up: migration_20260729_000007_checkout_hold_session_released.up,
+    down: migration_20260729_000007_checkout_hold_session_released.down,
+    name: '20260729_000007_checkout_hold_session_released',
   },
   {
     up: migration_20260730_000001_courses_access_window_mode.up,

--- a/apps/atnd-me/src/payload-types.ts
+++ b/apps/atnd-me/src/payload-types.ts
@@ -1230,17 +1230,39 @@ export interface Course {
   /**
    * Course description shown on the public detail page About section.
    */
-  about?: string | null;
+  about?: {
+    root: {
+      type: string;
+      children: {
+        type: any;
+        version: number;
+        [k: string]: unknown;
+      }[];
+      direction: ('ltr' | 'rtl') | null;
+      format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+      indent: number;
+      version: number;
+    };
+    [k: string]: unknown;
+  } | null;
   /**
-   * Fixed cohort start. Use with end date (not with duration).
+   * Hero cover for the course listing and detail pages.
+   */
+  coverImage?: (number | null) | Media;
+  /**
+   * Choose one: fixed cohort dates, or access length starting from purchase.
+   */
+  accessWindowMode: 'fixed' | 'duration';
+  /**
+   * Fixed cohort start date.
    */
   startDate?: string | null;
   /**
-   * Fixed cohort end. Use with start date (not with duration).
+   * Fixed cohort end date.
    */
   endDate?: string | null;
   /**
-   * Purchase-relative length (e.g. 8). Use with duration unit (not with fixed dates).
+   * Access length from purchase (e.g. 8).
    */
   durationLength?: number | null;
   /**
@@ -4584,6 +4606,8 @@ export interface CoursesSelect<T extends boolean = true> {
   title?: T;
   slug?: T;
   about?: T;
+  coverImage?: T;
+  accessWindowMode?: T;
   startDate?: T;
   endDate?: T;
   durationLength?: T;

--- a/apps/atnd-me/src/payload-types.ts
+++ b/apps/atnd-me/src/payload-types.ts
@@ -70,6 +70,7 @@ export interface Config {
     timeslots: Timeslot;
     scheduler: Scheduler;
     'post-booking-email-deliveries': PostBookingEmailDelivery;
+    'course-email-deliveries': CourseEmailDelivery;
     'staff-members': StaffMember;
     'event-types': EventType;
     tenants: Tenant;
@@ -77,8 +78,10 @@ export interface Config {
     'discount-codes': DiscountCode;
     'drop-ins': DropIn;
     'class-pass-types': ClassPassType;
+    courses: Course;
     plans: Plan;
     'class-passes': ClassPass;
+    'course-enrollments': CourseEnrollment;
     subscriptions: Subscription;
     transactions: Transaction;
     'booking-checkout-holds': BookingCheckoutHold;
@@ -126,6 +129,7 @@ export interface Config {
     timeslots: TimeslotsSelect<false> | TimeslotsSelect<true>;
     scheduler: SchedulerSelect<false> | SchedulerSelect<true>;
     'post-booking-email-deliveries': PostBookingEmailDeliveriesSelect<false> | PostBookingEmailDeliveriesSelect<true>;
+    'course-email-deliveries': CourseEmailDeliveriesSelect<false> | CourseEmailDeliveriesSelect<true>;
     'staff-members': StaffMembersSelect<false> | StaffMembersSelect<true>;
     'event-types': EventTypesSelect<false> | EventTypesSelect<true>;
     tenants: TenantsSelect<false> | TenantsSelect<true>;
@@ -133,8 +137,10 @@ export interface Config {
     'discount-codes': DiscountCodesSelect<false> | DiscountCodesSelect<true>;
     'drop-ins': DropInsSelect<false> | DropInsSelect<true>;
     'class-pass-types': ClassPassTypesSelect<false> | ClassPassTypesSelect<true>;
+    courses: CoursesSelect<false> | CoursesSelect<true>;
     plans: PlansSelect<false> | PlansSelect<true>;
     'class-passes': ClassPassesSelect<false> | ClassPassesSelect<true>;
+    'course-enrollments': CourseEnrollmentsSelect<false> | CourseEnrollmentsSelect<true>;
     subscriptions: SubscriptionsSelect<false> | SubscriptionsSelect<true>;
     transactions: TransactionsSelect<false> | TransactionsSelect<true>;
     'booking-checkout-holds': BookingCheckoutHoldsSelect<false> | BookingCheckoutHoldsSelect<true>;
@@ -181,6 +187,7 @@ export interface Config {
     tasks: {
       generateTimeslotsFromSchedule: TaskGenerateTimeslotsFromSchedule;
       sendPostBookingEmail: TaskSendPostBookingEmail;
+      sendCourseEmail: TaskSendCourseEmail;
       createCollectionExport: TaskCreateCollectionExport;
       createCollectionImport: TaskCreateCollectionImport;
       schedulePublish: TaskSchedulePublish;
@@ -478,6 +485,7 @@ export interface Page {
     | MarketingHeroBlock
     | ThreeColumnLayoutBlock
     | TwoColumnLayoutBlock
+    | EventBlock
     | AboutBlock
     | SimpleAboutBlock
     | LocationBlock
@@ -568,7 +576,6 @@ export interface Page {
         blockType: 'dhLiveMembership';
       }
     | GiftVoucherCheckoutBlock
-    | EventBlock
     | CroiLanHeroWithLocationBlock
     | ClFindSanctuaryBlock
     | ClMissionBlock
@@ -1075,6 +1082,10 @@ export interface EventType {
      */
     allowedClassPasses?: (number | ClassPassType)[] | null;
     /**
+     * Courses that grant free booking of this event type during the enrollee's access window.
+     */
+    allowedCourses?: (number | Course)[] | null;
+    /**
      * Membership plans that grant access to this class option. Users with an active subscription to a selected plan can book without paying per session.
      */
     allowedPlans?: (number | Plan)[] | null;
@@ -1199,6 +1210,106 @@ export interface ClassPassType {
    */
   skipSync?: boolean | null;
   deletedAt?: string | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * Courses grant enrolled users free booking of allowed event types during an access window.
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "courses".
+ */
+export interface Course {
+  id: number;
+  tenant?: (number | null) | Tenant;
+  title: string;
+  /**
+   * URL slug for /courses/[slug]. Unique per tenant when multi-tenant.
+   */
+  slug: string;
+  /**
+   * Course description shown on the public detail page About section.
+   */
+  about?: string | null;
+  /**
+   * Fixed cohort start. Use with end date (not with duration).
+   */
+  startDate?: string | null;
+  /**
+   * Fixed cohort end. Use with start date (not with duration).
+   */
+  endDate?: string | null;
+  /**
+   * Purchase-relative length (e.g. 8). Use with duration unit (not with fixed dates).
+   */
+  durationLength?: number | null;
+  /**
+   * Unit for purchase-relative duration.
+   */
+  durationUnit?: ('days' | 'weeks') | null;
+  /**
+   * Event types enrollees may book during their access window.
+   */
+  allowedEventTypes: (number | EventType)[];
+  /**
+   * Optional capacity. Leave blank for unlimited.
+   */
+  maxEnrollments?: number | null;
+  /**
+   * Link to a Stripe product with a one-time default price.
+   */
+  stripeProductId?: string | null;
+  /**
+   * Price information. Synced from Stripe when a product is linked.
+   */
+  priceInformation?: {
+    /**
+     * One-time price in euros (from Stripe default price)
+     */
+    price?: number | null;
+  };
+  /**
+   * Open courses can be purchased; archived cannot be used for booking.
+   */
+  status: 'draft' | 'open' | 'closed' | 'archived';
+  /**
+   * Emails sent to the enrollee after purchase or relative to their access window (start/end). Scheduled emails send at 9:00 local.
+   */
+  courseEmails?:
+    | {
+        cc?: string | null;
+        bcc?: string | null;
+        replyTo: string;
+        emailFrom?: string | null;
+        subject: string;
+        /**
+         * Enter the message that should be sent in this email.
+         */
+        message?: {
+          root: {
+            type: string;
+            children: {
+              type: any;
+              version: number;
+              [k: string]: unknown;
+            }[];
+            direction: ('ltr' | 'rtl') | null;
+            format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+            indent: number;
+            version: number;
+          };
+          [k: string]: unknown;
+        } | null;
+        sendTiming:
+          | 'after_purchase'
+          | 'one_week_before_start'
+          | 'one_day_before_start'
+          | 'one_day_after_start'
+          | 'one_day_before_end'
+          | 'one_day_after_end';
+        id?: string | null;
+      }[]
+    | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -1512,7 +1623,6 @@ export interface ThreeColumnLayoutBlock {
             blockType: 'dhLiveMembership';
           }
         | GiftVoucherCheckoutBlock
-        | EventBlock
         | HeroScheduleSanctuaryBlock
         | CroiLanHeroWithLocationBlock
         | ClFindSanctuaryBlock
@@ -2632,53 +2742,6 @@ export interface GiftVoucherCheckoutBlock {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "EventBlock".
- */
-export interface EventBlock {
-  /**
-   * Choose the event type, then a date, then the timeslot.
-   */
-  eventType: number | EventType;
-  /**
-   * Pick a date to list timeslots for that day.
-   */
-  timeslotDate?: string | null;
-  /**
-   * Active timeslots for the selected event type and date. Host, capacity, and ticket price come from the timeslot / event type.
-   */
-  timeslot?: (number | null) | Timeslot;
-  /**
-   * Hero cover for the event page. Falls back to a solid background when empty.
-   */
-  coverImage?: (number | null) | Media;
-  /**
-   * Event description shown in the About section. Falls back to the event type description when empty.
-   */
-  about?: {
-    root: {
-      type: string;
-      children: {
-        type: any;
-        version: number;
-        [k: string]: unknown;
-      }[];
-      direction: ('ltr' | 'rtl') | null;
-      format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
-      indent: number;
-      version: number;
-    };
-    [k: string]: unknown;
-  } | null;
-  /**
-   * Optional. Paste a Google Maps link (including maps.app.goo.gl). Falls back to the branch address when empty.
-   */
-  mapUrl?: string | null;
-  id?: string | null;
-  blockName?: string | null;
-  blockType: 'event';
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "CroiLanHeroWithLocationBlock".
  */
 export interface CroiLanHeroWithLocationBlock {
@@ -3013,7 +3076,6 @@ export interface TwoColumnLayoutBlock {
             blockType: 'dhLiveMembership';
           }
         | GiftVoucherCheckoutBlock
-        | EventBlock
         | HeroScheduleSanctuaryBlock
         | CroiLanHeroWithLocationBlock
         | ClFindSanctuaryBlock
@@ -3118,7 +3180,6 @@ export interface TwoColumnLayoutBlock {
             blockType: 'dhLiveMembership';
           }
         | GiftVoucherCheckoutBlock
-        | EventBlock
         | HeroScheduleSanctuaryBlock
         | CroiLanHeroWithLocationBlock
         | ClFindSanctuaryBlock
@@ -3131,6 +3192,53 @@ export interface TwoColumnLayoutBlock {
   id?: string | null;
   blockName?: string | null;
   blockType: 'twoColumnLayout';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "EventBlock".
+ */
+export interface EventBlock {
+  /**
+   * Choose the event type, then a date, then the timeslot.
+   */
+  eventType: number | EventType;
+  /**
+   * Optional filter — pick a date to list timeslots for that day. You can create a timeslot if none exist.
+   */
+  timeslotDate?: string | null;
+  /**
+   * Active timeslots for the selected event type and date. Host, capacity, and ticket price come from the timeslot / event type. If none exist for the selected date, you can create a timeslot with that date and event type.
+   */
+  timeslot?: (number | null) | Timeslot;
+  /**
+   * Hero cover for the event page. Falls back to a solid background when empty.
+   */
+  coverImage?: (number | null) | Media;
+  /**
+   * Event description shown in the About section. Falls back to the event type description when empty.
+   */
+  about?: {
+    root: {
+      type: string;
+      children: {
+        type: any;
+        version: number;
+        [k: string]: unknown;
+      }[];
+      direction: ('ltr' | 'rtl') | null;
+      format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+      indent: number;
+      version: number;
+    };
+    [k: string]: unknown;
+  } | null;
+  /**
+   * Optional. Paste a Google Maps link (including maps.app.goo.gl). Falls back to the branch address when empty.
+   */
+  mapUrl?: string | null;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'event';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -3172,7 +3280,7 @@ export interface Booking {
   /**
    * Set by API when creating; used to create a booking-transaction. Hidden from normal create flow.
    */
-  paymentMethodUsed?: ('stripe' | 'class_pass' | 'subscription') | null;
+  paymentMethodUsed?: ('stripe' | 'class_pass' | 'subscription' | 'course_enrollment') | null;
   /**
    * Set when paymentMethodUsed is class_pass; used to decrement the correct pass.
    */
@@ -3181,6 +3289,10 @@ export interface Booking {
    * Set when paymentMethodUsed is subscription; used to create a booking-transaction referencing the subscription.
    */
   subscriptionIdUsed?: number | null;
+  /**
+   * Set when paymentMethodUsed is course_enrollment; links the booking to the enrollment used.
+   */
+  courseEnrollmentIdUsed?: number | null;
   /**
    * Payment transactions for this booking (Stripe, class pass, or subscription). Injected by @repo/bookings-payments when enabled.
    */
@@ -3325,6 +3437,76 @@ export interface PostBookingEmailDelivery {
    * Booking that triggered scheduling or send.
    */
   triggerBooking?: (number | null) | Booking;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * Tracks scheduled and sent course emails for idempotency.
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "course-email-deliveries".
+ */
+export interface CourseEmailDelivery {
+  id: number;
+  tenant?: (number | null) | Tenant;
+  user: number | User;
+  enrollment: number | CourseEnrollment;
+  course: number | Course;
+  /**
+   * ID of the courseEmails array entry that triggered this delivery.
+   */
+  emailConfigId: string;
+  sendTiming:
+    | 'after_purchase'
+    | 'one_week_before_start'
+    | 'one_day_before_start'
+    | 'one_day_after_start'
+    | 'one_day_before_end'
+    | 'one_day_after_end';
+  status: 'scheduled' | 'sent' | 'cancelled';
+  /**
+   * Payload job queued for scheduled delivery.
+   */
+  payloadJobId?: number | null;
+  scheduledFor?: string | null;
+  sentAt?: string | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * Purchased course enrollments with stamped access windows
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "course-enrollments".
+ */
+export interface CourseEnrollment {
+  id: number;
+  tenant?: (number | null) | Tenant;
+  /**
+   * Enrolled user
+   */
+  user: number | User;
+  /**
+   * Course purchased
+   */
+  course: number | Course;
+  status: 'active' | 'cancelled' | 'completed';
+  /**
+   * When the course was purchased
+   */
+  purchasedAt: string;
+  /**
+   * Start of booking access window (stamped at purchase)
+   */
+  accessStartsAt: string;
+  /**
+   * End of booking access window (stamped at purchase)
+   */
+  accessEndsAt: string;
+  /**
+   * External transaction id (e.g. Stripe payment intent id).
+   */
+  transactionId?: string | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -3887,6 +4069,7 @@ export interface PayloadJob {
           | 'inline'
           | 'generateTimeslotsFromSchedule'
           | 'sendPostBookingEmail'
+          | 'sendCourseEmail'
           | 'createCollectionExport'
           | 'createCollectionImport'
           | 'schedulePublish';
@@ -3927,6 +4110,7 @@ export interface PayloadJob {
         | 'inline'
         | 'generateTimeslotsFromSchedule'
         | 'sendPostBookingEmail'
+        | 'sendCourseEmail'
         | 'createCollectionExport'
         | 'createCollectionImport'
         | 'schedulePublish'
@@ -3958,6 +4142,10 @@ export interface PayloadLockedDocument {
         value: number | PostBookingEmailDelivery;
       } | null)
     | ({
+        relationTo: 'course-email-deliveries';
+        value: number | CourseEmailDelivery;
+      } | null)
+    | ({
         relationTo: 'staff-members';
         value: number | StaffMember;
       } | null)
@@ -3986,12 +4174,20 @@ export interface PayloadLockedDocument {
         value: number | ClassPassType;
       } | null)
     | ({
+        relationTo: 'courses';
+        value: number | Course;
+      } | null)
+    | ({
         relationTo: 'plans';
         value: number | Plan;
       } | null)
     | ({
         relationTo: 'class-passes';
         value: number | ClassPass;
+      } | null)
+    | ({
+        relationTo: 'course-enrollments';
+        value: number | CourseEnrollment;
       } | null)
     | ({
         relationTo: 'subscriptions';
@@ -4193,6 +4389,24 @@ export interface PostBookingEmailDeliveriesSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "course-email-deliveries_select".
+ */
+export interface CourseEmailDeliveriesSelect<T extends boolean = true> {
+  tenant?: T;
+  user?: T;
+  enrollment?: T;
+  course?: T;
+  emailConfigId?: T;
+  sendTiming?: T;
+  status?: T;
+  payloadJobId?: T;
+  scheduledFor?: T;
+  sentAt?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "staff-members_select".
  */
 export interface StaffMembersSelect<T extends boolean = true> {
@@ -4219,6 +4433,7 @@ export interface EventTypesSelect<T extends boolean = true> {
     | {
         allowedDropIn?: T;
         allowedClassPasses?: T;
+        allowedCourses?: T;
         allowedPlans?: T;
       };
   postBookingEmails?:
@@ -4362,6 +4577,43 @@ export interface ClassPassTypesSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "courses_select".
+ */
+export interface CoursesSelect<T extends boolean = true> {
+  tenant?: T;
+  title?: T;
+  slug?: T;
+  about?: T;
+  startDate?: T;
+  endDate?: T;
+  durationLength?: T;
+  durationUnit?: T;
+  allowedEventTypes?: T;
+  maxEnrollments?: T;
+  stripeProductId?: T;
+  priceInformation?:
+    | T
+    | {
+        price?: T;
+      };
+  status?: T;
+  courseEmails?:
+    | T
+    | {
+        cc?: T;
+        bcc?: T;
+        replyTo?: T;
+        emailFrom?: T;
+        subject?: T;
+        message?: T;
+        sendTiming?: T;
+        id?: T;
+      };
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "plans_select".
  */
 export interface PlansSelect<T extends boolean = true> {
@@ -4413,6 +4665,22 @@ export interface ClassPassesSelect<T extends boolean = true> {
   transactionId?: T;
   status?: T;
   notes?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "course-enrollments_select".
+ */
+export interface CourseEnrollmentsSelect<T extends boolean = true> {
+  tenant?: T;
+  user?: T;
+  course?: T;
+  status?: T;
+  purchasedAt?: T;
+  accessStartsAt?: T;
+  accessEndsAt?: T;
+  transactionId?: T;
   updatedAt?: T;
   createdAt?: T;
 }
@@ -4482,6 +4750,7 @@ export interface PagesSelect<T extends boolean = true> {
         marketingHero?: T | MarketingHeroBlockSelect<T>;
         threeColumnLayout?: T | ThreeColumnLayoutBlockSelect<T>;
         twoColumnLayout?: T | TwoColumnLayoutBlockSelect<T>;
+        event?: T | EventBlockSelect<T>;
         about?: T | AboutBlockSelect<T>;
         simpleAbout?: T | SimpleAboutBlockSelect<T>;
         location?: T | LocationBlockSelect<T>;
@@ -4585,7 +4854,6 @@ export interface PagesSelect<T extends boolean = true> {
               blockName?: T;
             };
         giftVoucherCheckout?: T | GiftVoucherCheckoutBlockSelect<T>;
-        event?: T | EventBlockSelect<T>;
         clHeroLoc?: T | CroiLanHeroWithLocationBlockSelect<T>;
         clFindSanctuary?: T | ClFindSanctuaryBlockSelect<T>;
         clMission?: T | ClMissionBlockSelect<T>;
@@ -4931,7 +5199,6 @@ export interface ThreeColumnLayoutBlockSelect<T extends boolean = true> {
               blockName?: T;
             };
         giftVoucherCheckout?: T | GiftVoucherCheckoutBlockSelect<T>;
-        event?: T | EventBlockSelect<T>;
         heroScheduleSanctuary?: T | HeroScheduleSanctuaryBlockSelect<T>;
         clHeroLoc?: T | CroiLanHeroWithLocationBlockSelect<T>;
         clFindSanctuary?: T | ClFindSanctuaryBlockSelect<T>;
@@ -5564,20 +5831,6 @@ export interface GiftVoucherCheckoutBlockSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "EventBlock_select".
- */
-export interface EventBlockSelect<T extends boolean = true> {
-  eventType?: T;
-  timeslotDate?: T;
-  timeslot?: T;
-  coverImage?: T;
-  about?: T;
-  mapUrl?: T;
-  id?: T;
-  blockName?: T;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "CroiLanHeroWithLocationBlock_select".
  */
 export interface CroiLanHeroWithLocationBlockSelect<T extends boolean = true> {
@@ -5853,7 +6106,6 @@ export interface TwoColumnLayoutBlockSelect<T extends boolean = true> {
               blockName?: T;
             };
         giftVoucherCheckout?: T | GiftVoucherCheckoutBlockSelect<T>;
-        event?: T | EventBlockSelect<T>;
         heroScheduleSanctuary?: T | HeroScheduleSanctuaryBlockSelect<T>;
         clHeroLoc?: T | CroiLanHeroWithLocationBlockSelect<T>;
         clFindSanctuary?: T | ClFindSanctuaryBlockSelect<T>;
@@ -5971,7 +6223,6 @@ export interface TwoColumnLayoutBlockSelect<T extends boolean = true> {
               blockName?: T;
             };
         giftVoucherCheckout?: T | GiftVoucherCheckoutBlockSelect<T>;
-        event?: T | EventBlockSelect<T>;
         heroScheduleSanctuary?: T | HeroScheduleSanctuaryBlockSelect<T>;
         clHeroLoc?: T | CroiLanHeroWithLocationBlockSelect<T>;
         clFindSanctuary?: T | ClFindSanctuaryBlockSelect<T>;
@@ -5980,6 +6231,20 @@ export interface TwoColumnLayoutBlockSelect<T extends boolean = true> {
         clSaunaBenefits?: T | ClSaunaBenefitsBlockSelect<T>;
         hwHeroServices?: T | HwHeroServicesBlockSelect<T>;
       };
+  id?: T;
+  blockName?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "EventBlock_select".
+ */
+export interface EventBlockSelect<T extends boolean = true> {
+  eventType?: T;
+  timeslotDate?: T;
+  timeslot?: T;
+  coverImage?: T;
+  about?: T;
+  mapUrl?: T;
   id?: T;
   blockName?: T;
 }
@@ -6509,6 +6774,7 @@ export interface BookingsSelect<T extends boolean = true> {
   paymentMethodUsed?: T;
   classPassIdUsed?: T;
   subscriptionIdUsed?: T;
+  courseEnrollmentIdUsed?: T;
   transactions?: T;
   updatedAt?: T;
   createdAt?: T;
@@ -6662,6 +6928,10 @@ export interface PlatformFee {
      */
     classPassPercent: number;
     /**
+     * Default fee for course enrollments.
+     */
+    coursePercent: number;
+    /**
      * Default fee for subscription payments.
      */
     subscriptionPercent: number;
@@ -6684,6 +6954,10 @@ export interface PlatformFee {
          * Leave empty to use default.
          */
         classPassPercent?: number | null;
+        /**
+         * Leave empty to use default.
+         */
+        coursePercent?: number | null;
         /**
          * Leave empty to use default.
          */
@@ -6721,6 +6995,7 @@ export interface PlatformFeesSelect<T extends boolean = true> {
     | {
         dropInPercent?: T;
         classPassPercent?: T;
+        coursePercent?: T;
         subscriptionPercent?: T;
         giftVoucherPercent?: T;
       };
@@ -6730,6 +7005,7 @@ export interface PlatformFeesSelect<T extends boolean = true> {
         tenant?: T;
         dropInPercent?: T;
         classPassPercent?: T;
+        coursePercent?: T;
         subscriptionPercent?: T;
         giftVoucherPercent?: T;
         id?: T;
@@ -6797,6 +7073,14 @@ export interface TaskSendPostBookingEmail {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "TaskSendCourseEmail".
+ */
+export interface TaskSendCourseEmail {
+  input?: unknown;
+  output?: unknown;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "TaskCreateCollectionExport".
  */
 export interface TaskCreateCollectionExport {
@@ -6817,6 +7101,7 @@ export interface TaskCreateCollectionExport {
       | 'scheduler'
       | 'locations'
       | 'post-booking-email-deliveries'
+      | 'course-email-deliveries'
       | 'redirects'
       | 'forms'
       | 'search'
@@ -6830,6 +7115,8 @@ export interface TaskCreateCollectionExport {
       | 'drop-ins'
       | 'class-pass-types'
       | 'class-passes'
+      | 'courses'
+      | 'course-enrollments'
       | 'subscriptions'
       | 'plans'
       | 'transactions'
@@ -6946,11 +7233,11 @@ export interface EventCheckoutBlock {
    */
   eventType: number | EventType;
   /**
-   * Pick a date to list timeslots for that day.
+   * Optional filter — pick a date to list timeslots for that day. You can create a timeslot if none exist.
    */
   timeslotDate?: string | null;
   /**
-   * Active timeslots for the selected event type and date. Checkout quantity, fees, and Stripe payment bind to this timeslot.
+   * Active timeslots for the selected event type and date. Checkout quantity, fees, and Stripe payment bind to this timeslot. If none exist for the selected date, you can create a timeslot with that date and event type.
    */
   timeslot?: (number | null) | Timeslot;
   id?: string | null;

--- a/apps/atnd-me/src/payload-types.ts
+++ b/apps/atnd-me/src/payload-types.ts
@@ -3685,7 +3685,11 @@ export interface BookingCheckoutHold {
    * When the hold was first created; used for max lifetime cap.
    */
   firstUpsertedAt?: string | null;
-  status: 'active' | 'consumed' | 'expired';
+  status: 'active' | 'consumed' | 'expired' | 'released';
+  /**
+   * Client checkout attempt id. After release, upserts with the same id are ignored so late in-flight reserves cannot recreate capacity holds.
+   */
+  checkoutSessionId?: string | null;
   stripePaymentIntentId?: string | null;
   /**
    * Set when hold expires without fulfillment (e.g. refund path).
@@ -4753,6 +4757,7 @@ export interface BookingCheckoutHoldsSelect<T extends boolean = true> {
   expiresAt?: T;
   firstUpsertedAt?: T;
   status?: T;
+  checkoutSessionId?: T;
   stripePaymentIntentId?: T;
   failureReason?: T;
   updatedAt?: T;

--- a/apps/atnd-me/src/payload.config.ts
+++ b/apps/atnd-me/src/payload.config.ts
@@ -17,12 +17,14 @@ import { Footer } from './collections/Footer'
 import { Scheduler } from './collections/Scheduler'
 import { Locations } from './collections/Locations'
 import { PostBookingEmailDeliveries } from './collections/PostBookingEmailDeliveries'
+import { CourseEmailDeliveries } from './collections/CourseEmailDeliveries'
 import { PlatformFees } from './globals/PlatformFees'
 import { plugins } from './plugins'
 import { defaultLexical } from '@/fields/defaultLexical'
 import { getServerSideURL } from './utilities/getURL'
 import { generateTimeslotsFromScheduleWithTenant } from './tasks/generate-timeslots-with-tenant'
 import { sendPostBookingEmailTask } from './tasks/send-post-booking-email'
+import { sendCourseEmailTask } from './tasks/send-course-email'
 import { createCustomersProxy } from '@repo/bookings-payments'
 import { getStripeAccountIdForRequest } from '@/lib/stripe-connect/getStripeAccountIdForRequest'
 import { resolvePayloadEmailConfig } from './utilities/emailConfig'
@@ -167,7 +169,7 @@ export default buildConfig({
       }
       : {}),
   }),
-  collections: [Pages, Posts, Media, Categories, Users, Tenants, DiscountCodes, Navbar, Footer, Scheduler, Locations, PostBookingEmailDeliveries],
+  collections: [Pages, Posts, Media, Categories, Users, Tenants, DiscountCodes, Navbar, Footer, Scheduler, Locations, PostBookingEmailDeliveries, CourseEmailDeliveries],
   // Global multipart upload limits (busboy). Without this, fileSize defaults to Infinity.
   // abortOnLimit must be true — otherwise oversized files are truncated instead of rejected.
   // Note: Payload still drains the request body before responding, so admin UX also relies on
@@ -244,6 +246,10 @@ export default buildConfig({
       {
         slug: 'sendPostBookingEmail',
         handler: sendPostBookingEmailTask,
+      },
+      {
+        slug: 'sendCourseEmail',
+        handler: sendCourseEmailTask,
       },
     ],
   },

--- a/apps/atnd-me/src/plugins/index.ts
+++ b/apps/atnd-me/src/plugins/index.ts
@@ -432,6 +432,9 @@ export const plugins: Plugin[] = [
       admin: {
         group: 'Bookings',
         useAsTitle: 'adminTitle',
+        // Keep timeslots out of Lexical internal-link / relationship pickers.
+        enableRichTextLink: false,
+        enableRichTextRelationship: false,
         components: {
           views: {
             list: {

--- a/apps/atnd-me/src/plugins/index.ts
+++ b/apps/atnd-me/src/plugins/index.ts
@@ -99,6 +99,7 @@ import { Page, Post, Tenant } from '@/payload-types'
 import { getAbsoluteURL, getServerSideURL, getTenantSiteURL } from '@/utilities/getURL'
 import { ATND_ME_BOOKINGS_COLLECTION_SLUGS } from '@/constants/bookings-collection-slugs'
 import { courseEmailsField } from '@/fields/courseEmailFields'
+import { simpleLexical } from '@/fields/simpleLexical'
 import { triggerCourseEmailAfterChange } from '@/lib/course-email/maybe-trigger-course-email'
 import { sortAdminNavGroupsPlugin } from './sort-admin-nav-groups'
 import { userDataImportExportPlugin } from './import-export'
@@ -848,6 +849,9 @@ export const plugins: Plugin[] = [
           [
             ...defaultFields.map((field) => {
               const name = 'name' in field ? field.name : undefined
+              if (name === 'about' && field.type === 'richText') {
+                return { ...field, editor: simpleLexical }
+              }
               if (name === 'priceInformation' || name === 'stripeProductId') {
                 return name === 'priceInformation'
                   ? withNestedFieldAccess(field, adminOrTenantAdminFieldAccess)

--- a/apps/atnd-me/src/plugins/index.ts
+++ b/apps/atnd-me/src/plugins/index.ts
@@ -98,6 +98,8 @@ import { syncStaffPublicMediaPlugin } from './sync-staff-public-media'
 import { Page, Post, Tenant } from '@/payload-types'
 import { getAbsoluteURL, getServerSideURL, getTenantSiteURL } from '@/utilities/getURL'
 import { ATND_ME_BOOKINGS_COLLECTION_SLUGS } from '@/constants/bookings-collection-slugs'
+import { courseEmailsField } from '@/fields/courseEmailFields'
+import { triggerCourseEmailAfterChange } from '@/lib/course-email/maybe-trigger-course-email'
 import { sortAdminNavGroupsPlugin } from './sort-admin-nav-groups'
 import { userDataImportExportPlugin } from './import-export'
 import { tenantScopedExportJobsPlugin } from './tenant-scoped-export-jobs'
@@ -670,6 +672,7 @@ export const plugins: Plugin[] = [
             { label: 'Stripe', value: 'stripe' },
             { label: 'Class pass', value: 'class_pass' },
             { label: 'Subscription', value: 'subscription' },
+            { label: 'Course enrollment', value: 'course_enrollment' },
           ],
           required: false,
           admin: { description: 'Set by API when creating; used to create a booking-transaction. Hidden from normal create flow.' },
@@ -694,6 +697,18 @@ export const plugins: Plugin[] = [
             description: 'Set when paymentMethodUsed is subscription; used to create a booking-transaction referencing the subscription.',
             condition: (_: unknown, sibling: { paymentMethodUsed?: string }) =>
               sibling?.paymentMethodUsed === 'subscription',
+          },
+        },
+        {
+          name: 'courseEnrollmentIdUsed',
+          type: 'number',
+          label: 'Course enrollment id (set at create)',
+          required: false,
+          admin: {
+            description:
+              'Set when paymentMethodUsed is course_enrollment; links the booking to the enrollment used.',
+            condition: (_: unknown, sibling: { paymentMethodUsed?: string }) =>
+              sibling?.paymentMethodUsed === 'course_enrollment',
           },
         },
       ],
@@ -817,6 +832,48 @@ export const plugins: Plugin[] = [
         }),
       },
       getStripeAccountIdForRequest,
+    },
+    courses: {
+      enabled: true,
+      eventTypesSlug: 'event-types',
+      coursesOverrides: {
+        access: {
+          admin: productsRequireStripeConnectAdmin,
+          read: productsRequireStripeConnectRead,
+          create: productsRequireStripeConnectCreate,
+          update: productsRequireStripeConnectUpdate,
+          delete: productsRequireStripeConnectDelete,
+        },
+        fields: ({ defaultFields }) =>
+          [
+            ...defaultFields.map((field) => {
+              const name = 'name' in field ? field.name : undefined
+              if (name === 'priceInformation' || name === 'stripeProductId') {
+                return name === 'priceInformation'
+                  ? withNestedFieldAccess(field, adminOrTenantAdminFieldAccess)
+                  : { ...field, access: adminOnlyFieldAccess }
+              }
+              return field
+            }),
+            courseEmailsField,
+          ] as Field[],
+      },
+      courseEnrollmentsOverrides: {
+        access: {
+          admin: productsRequireStripeConnectAdmin,
+          read: productsRequireStripeConnectRead,
+          create: productsRequireStripeConnectCreate,
+          update: productsRequireStripeConnectUpdate,
+          delete: productsRequireStripeConnectDelete,
+        },
+        hooks: ({ defaultHooks }) => ({
+          ...defaultHooks,
+          afterChange: [
+            ...(defaultHooks.afterChange ?? []),
+            triggerCourseEmailAfterChange,
+          ],
+        }),
+      },
     },
     // Drop-ins: single-use payment options per class option
     dropIns: {
@@ -1014,12 +1071,15 @@ export const plugins: Plugin[] = [
       // From @repo/bookings-payments
       'class-pass-types': {}, // Pass types (e.g. Fitness Only, Sauna Only); tenant-scoped
       'class-passes': {}, // Class passes; tenant-scoped
+      courses: {}, // Course products; tenant-scoped
+      'course-enrollments': {}, // Purchased course enrollments; tenant-scoped
       'transactions': {}, // Payment records per booking (Stripe, class pass, subscription); tenant-scoped via plugin overrides
       'booking-checkout-holds': {}, // Ephemeral checkout capacity holds; tenant-scoped
       'drop-ins': {}, // Drop-in payment options; tenant-scoped
       plans: {}, // Membership plans (collection slug: plans); tenant-scoped
       'discount-codes': {}, // Phase 4.5: Stripe coupons + promotion codes; tenant-scoped
       'post-booking-email-deliveries': {}, // Post-booking email idempotency tracking
+      'course-email-deliveries': {}, // Course email idempotency tracking
       locations: {}, // Phase 7: branches/sites per tenant; tenant-scoped
       subscriptions: {}, // User subscriptions; tenant-scoped
       media: {}, // Tenant-scoped media uploads
@@ -1050,6 +1110,8 @@ export const plugins: Plugin[] = [
       'bookings',
       'class-pass-types',
       'class-passes',
+      'courses',
+      'course-enrollments',
       'transactions',
       'booking-checkout-holds',
       'drop-ins',
@@ -1074,6 +1136,8 @@ export const plugins: Plugin[] = [
       'bookings',
       'class-pass-types',
       'class-passes',
+      'courses',
+      'course-enrollments',
       'transactions',
       'booking-checkout-holds',
       'drop-ins',

--- a/apps/atnd-me/src/plugins/sync-staff-public-media.ts
+++ b/apps/atnd-me/src/plugins/sync-staff-public-media.ts
@@ -2,17 +2,19 @@ import type { Config, Plugin } from 'payload'
 
 import { syncPublicMediaFlags } from '@/utilities/syncPublicMedia'
 
+const PUBLIC_MEDIA_COLLECTIONS = new Set(['staff-members', 'courses'])
+
 /**
- * Staff profile images appear on the public schedule. Next/Image often fetches
- * `/api/media/file/...` without tenant cookies, so those media docs must be
- * marked `isPublic` when staff are saved (same as pages/navbar/footer).
+ * Staff profile images and course covers appear on public pages. Next/Image often
+ * fetches `/api/media/file/...` without tenant cookies, so those media docs must be
+ * marked `isPublic` when the parent doc is saved (same as pages/navbar/footer).
  */
 export const syncStaffPublicMediaPlugin =
   (): Plugin =>
   (config: Config): Config => ({
     ...config,
     collections: (config.collections ?? []).map((collection) => {
-      if (collection.slug !== 'staff-members') return collection
+      if (!PUBLIC_MEDIA_COLLECTIONS.has(collection.slug)) return collection
       const hooks = collection.hooks ?? {}
       return {
         ...collection,

--- a/apps/atnd-me/src/tasks/send-course-email.ts
+++ b/apps/atnd-me/src/tasks/send-course-email.ts
@@ -1,5 +1,6 @@
 import type { TaskHandler } from 'payload'
 import { COURSE_EMAIL_DELIVERIES_SLUG } from '@/collections/CourseEmailDeliveries'
+import { ATND_ME_BOOKINGS_COLLECTION_SLUGS } from '@/constants/bookings-collection-slugs'
 import { sendCourseEmail } from '@/lib/course-email/send-course-email'
 import type { CourseEmailConfig, CourseEmailJobInput } from '@/lib/course-email/types'
 import { resolveCourseEmailConfigById } from '@/lib/course-email/types'
@@ -21,7 +22,7 @@ export const sendCourseEmailTask: TaskHandler<'sendCourseEmail'> = async ({ inpu
 
   const enrollment = await req.payload
     .findByID({
-      collection: 'course-enrollments' as import('payload').CollectionSlug,
+      collection: ATND_ME_BOOKINGS_COLLECTION_SLUGS.courseEnrollments,
       id: enrollmentId,
       depth: 0,
       overrideAccess: true,
@@ -40,7 +41,7 @@ export const sendCourseEmailTask: TaskHandler<'sendCourseEmail'> = async ({ inpu
   }
 
   const course = await req.payload.findByID({
-    collection: 'courses' as import('payload').CollectionSlug,
+    collection: ATND_ME_BOOKINGS_COLLECTION_SLUGS.courses,
     id: courseId,
     depth: 0,
     overrideAccess: true,

--- a/apps/atnd-me/src/tasks/send-course-email.ts
+++ b/apps/atnd-me/src/tasks/send-course-email.ts
@@ -1,0 +1,82 @@
+import type { TaskHandler } from 'payload'
+import { COURSE_EMAIL_DELIVERIES_SLUG } from '@/collections/CourseEmailDeliveries'
+import { sendCourseEmail } from '@/lib/course-email/send-course-email'
+import type { CourseEmailConfig, CourseEmailJobInput } from '@/lib/course-email/types'
+import { resolveCourseEmailConfigById } from '@/lib/course-email/types'
+
+export const sendCourseEmailTask: TaskHandler<'sendCourseEmail'> = async ({ input, req }) => {
+  const jobInput = input as CourseEmailJobInput
+  const { deliveryId, userId, enrollmentId, emailConfigId, courseId } = jobInput
+
+  const delivery = await req.payload.findByID({
+    collection: COURSE_EMAIL_DELIVERIES_SLUG,
+    id: deliveryId,
+    depth: 0,
+    overrideAccess: true,
+  })
+
+  if (!delivery || delivery.status !== 'scheduled') {
+    return { output: { skipped: true, reason: 'delivery_not_scheduled' } }
+  }
+
+  const enrollment = await req.payload
+    .findByID({
+      collection: 'course-enrollments' as import('payload').CollectionSlug,
+      id: enrollmentId,
+      depth: 0,
+      overrideAccess: true,
+    })
+    .catch(() => null)
+
+  if (!enrollment || enrollment.status !== 'active') {
+    await req.payload.update({
+      collection: COURSE_EMAIL_DELIVERIES_SLUG,
+      id: deliveryId,
+      data: { status: 'cancelled' },
+      overrideAccess: true,
+      req,
+    })
+    return { output: { skipped: true, reason: 'enrollment_not_active' } }
+  }
+
+  const course = await req.payload.findByID({
+    collection: 'courses' as import('payload').CollectionSlug,
+    id: courseId,
+    depth: 0,
+    overrideAccess: true,
+  })
+
+  const config = resolveCourseEmailConfigById(
+    course as { courseEmails?: CourseEmailConfig[] | null },
+    emailConfigId,
+  )
+  if (!config) {
+    return { output: { skipped: true, reason: 'email_disabled' } }
+  }
+
+  const user = await req.payload.findByID({
+    collection: 'users',
+    id: userId,
+    depth: 0,
+    overrideAccess: true,
+  })
+
+  await sendCourseEmail({
+    payload: req.payload,
+    user,
+    config,
+  })
+
+  await req.payload.update({
+    collection: COURSE_EMAIL_DELIVERIES_SLUG,
+    id: deliveryId,
+    data: {
+      status: 'sent',
+      sentAt: new Date().toISOString(),
+    },
+    overrideAccess: true,
+    req,
+  })
+
+  return { output: { sent: true } }
+}

--- a/apps/atnd-me/src/utilities/syncPublicMedia.ts
+++ b/apps/atnd-me/src/utilities/syncPublicMedia.ts
@@ -155,6 +155,27 @@ async function getPublishedPublicMediaIds(req: PayloadRequest): Promise<Set<numb
     collectMediaIds(post, undefined, ids)
   }
 
+  // Course cover images appear on public listing/detail pages; Next/Image fetches
+  // `/api/media/file/...` without tenant cookies, so these must be marked isPublic.
+  const courses = await req.payload.find({
+    collection: 'courses',
+    where: { status: { not_equals: 'archived' } },
+    limit: 1000,
+    pagination: false,
+    depth: 1,
+    overrideAccess: true,
+    req,
+    select: {
+      id: true,
+      coverImage: true,
+      tenant: true,
+    } as any,
+  })
+
+  for (const course of courses.docs) {
+    collectMediaIds(course, undefined, ids)
+  }
+
   return ids
 }
 

--- a/apps/atnd-me/tests/e2e/booking-with-course.e2e.spec.ts
+++ b/apps/atnd-me/tests/e2e/booking-with-course.e2e.spec.ts
@@ -1,0 +1,151 @@
+/**
+ * Enrolled user books an allowed timeslot via the Course payment tab.
+ */
+import { test, expect } from './helpers/fixtures'
+import { loginAsRegularUserViaApi } from './helpers/auth-helpers'
+import { navigateToTenant } from './helpers/subdomain-helpers'
+import {
+  createTestEventType,
+  createTestTimeslot,
+  getPayloadInstance,
+} from './helpers/data-helpers'
+
+async function openBookingPage(args: {
+  page: Parameters<typeof test>[0]['page']
+  tenantSlug: string
+  lessonId: number
+}) {
+  const { page, tenantSlug, lessonId } = args
+  const bookingReady = page
+    .getByText(/select quantity|number of slots|book|payment methods/i)
+    .first()
+
+  for (let attempt = 0; attempt < 3; attempt++) {
+    await navigateToTenant(page, tenantSlug, '/')
+    await page.waitForLoadState('domcontentloaded').catch(() => null)
+    await navigateToTenant(page, tenantSlug, `/bookings/${lessonId}`)
+    await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => null)
+
+    const visible = await bookingReady.isVisible().catch(() => false)
+    if (visible) return
+    await page.waitForTimeout(process.env.CI ? 3000 : 1500)
+  }
+
+  await expect(bookingReady).toBeVisible({ timeout: 15000 })
+}
+
+test.describe('Booking with course enrollment', () => {
+  test.describe.configure({ timeout: 120_000, mode: 'serial' })
+
+  test('user with active enrollment sees Course tab and can confirm booking', async ({
+    page,
+    testData,
+  }) => {
+    test.setTimeout(120_000)
+    const payload = await getPayloadInstance()
+    const tenantId = testData.tenants[0]?.id
+    const tenantSlug = testData.tenants[0]?.slug
+    const w = testData.workerIndex
+    if (!tenantId || !tenantSlug) throw new Error('Tenant required')
+
+    await payload.update({
+      collection: 'tenants',
+      id: tenantId,
+      data: {
+        stripeConnectOnboardingStatus: 'active',
+        stripeConnectAccountId: null,
+      },
+      overrideAccess: true,
+    })
+
+    const co = await createTestEventType(tenantId, 'Course Only Class', 5, undefined, w)
+    const course = (await payload.create({
+      collection: 'courses',
+      data: {
+        title: `E2E Book Course w${w} ${Date.now()}`,
+        slug: `e2e-book-course-${w}-${Date.now()}`,
+        durationLength: 8,
+        durationUnit: 'weeks',
+        allowedEventTypes: [co.id],
+        status: 'open',
+        tenant: tenantId,
+        priceInformation: { price: 99 },
+      },
+      overrideAccess: true,
+      context: { skipStripeSync: true },
+    })) as { id: number }
+
+    await payload.update({
+      collection: 'event-types',
+      id: co.id,
+      data: { paymentMethods: { allowedCourses: [course.id] } },
+      overrideAccess: true,
+    })
+
+    const accessStartsAt = new Date(Date.now() - 86400000).toISOString()
+    const accessEndsAt = new Date(Date.now() + 86400000 * 60).toISOString()
+    await payload.create({
+      collection: 'course-enrollments',
+      data: {
+        user: testData.users.user1.id,
+        tenant: tenantId,
+        course: course.id,
+        status: 'active',
+        accessStartsAt,
+        accessEndsAt,
+        purchasedAt: new Date().toISOString(),
+        transactionId: `e2e_course_book_${w}_${Date.now()}`,
+      },
+      overrideAccess: true,
+    })
+
+    const start = new Date()
+    start.setDate(start.getDate() + 2)
+    start.setHours(14, 0, 0, 0)
+    const end = new Date(start)
+    end.setHours(15, 0, 0, 0)
+    const lesson = await createTestTimeslot(tenantId, co.id, start, end, undefined, true)
+
+    await new Promise((r) => setTimeout(r, 600))
+
+    await loginAsRegularUserViaApi(page, testData.users.user1.email, 'password', { tenantSlug })
+    await openBookingPage({ page, tenantSlug, lessonId: lesson.id })
+
+    await page.waitForTimeout(2000)
+    const courseTab = page.getByRole('tab', { name: /^course$/i })
+    await expect(courseTab).toBeVisible({ timeout: 15000 })
+    await courseTab.click()
+
+    await expect(
+      page.getByText(/use this course|confirm with course|use a course enrollment/i).first(),
+    ).toBeVisible({ timeout: 15000 })
+
+    const confirmBtn = page
+      .getByRole('button', { name: /confirm with course|use this course/i })
+      .first()
+    await expect(confirmBtn).toBeVisible()
+    await confirmBtn.click()
+
+    await expect(page.getByRole('heading', { name: /thank you/i })).toBeVisible({ timeout: 15000 })
+    await expect(page.getByText(/your booking has been confirmed/i)).toBeVisible()
+
+    await expect
+      .poll(async () => {
+        const bookings = await payload.find({
+          collection: 'bookings',
+          where: {
+            and: [
+              { user: { equals: testData.users.user1.id } },
+              { timeslot: { equals: lesson.id } },
+              { status: { equals: 'confirmed' } },
+            ],
+          },
+          limit: 5,
+          depth: 0,
+          overrideAccess: true,
+        })
+        return bookings.totalDocs
+      }, { timeout: 10000 })
+      .toBeGreaterThanOrEqual(1)
+  })
+})

--- a/apps/atnd-me/tests/e2e/course-auth-enroll.e2e.spec.ts
+++ b/apps/atnd-me/tests/e2e/course-auth-enroll.e2e.spec.ts
@@ -1,0 +1,130 @@
+/**
+ * Logged-in user enrolls from /courses/[slug]: PaymentIntent bootstrap + webhook enrollment.
+ */
+import { test, expect } from './helpers/fixtures'
+import { loginAsRegularUserViaApi } from './helpers/auth-helpers'
+import { navigateToTenant } from './helpers/subdomain-helpers'
+import { createTestEventType, getPayloadInstance } from './helpers/data-helpers'
+import { postCoursePurchaseWebhook } from './helpers/stripe-webhook-helpers'
+
+test.describe('Course auth enroll', () => {
+  test.describe.configure({ timeout: 120_000 })
+
+  test('logged-in user starts purchase and webhook creates enrollment', async ({
+    page,
+    testData,
+    request,
+  }) => {
+    const payload = await getPayloadInstance()
+    const tenantId = testData.tenants[0]?.id
+    const tenantSlug = testData.tenants[0]?.slug
+    const userId = testData.users.user1.id
+    const w = testData.workerIndex
+    if (!tenantId || !tenantSlug || !userId) throw new Error('Tenant/user required')
+
+    const connectAccountId = `acct_e2e_connected_course_auth_${tenantId}_${w}`
+    await payload.update({
+      collection: 'tenants',
+      id: tenantId,
+      data: {
+        stripeConnectOnboardingStatus: 'active',
+        stripeConnectAccountId: connectAccountId,
+      },
+      overrideAccess: true,
+    })
+
+    const eventType = await createTestEventType(tenantId, 'Course Auth Enroll Class', 8, undefined, w)
+    const slug = `e2e-course-auth-${w}-${Date.now()}`
+    const course = (await payload.create({
+      collection: 'courses',
+      data: {
+        title: `E2E Auth Enroll Course w${w}`,
+        slug,
+        durationLength: 8,
+        durationUnit: 'weeks',
+        allowedEventTypes: [eventType.id],
+        status: 'open',
+        tenant: tenantId,
+        priceInformation: { price: 99 },
+      },
+      overrideAccess: true,
+      context: { skipStripeSync: true },
+    })) as { id: number }
+
+    await loginAsRegularUserViaApi(page, testData.users.user1.email, 'password', {
+      request,
+      tenantSlug,
+    })
+
+    const purchaseResponsePromise = page.waitForResponse(
+      (res) =>
+        res.url().includes('/api/courses/purchase') &&
+        res.request().method() === 'POST' &&
+        res.status() === 200,
+      { timeout: 30_000 },
+    )
+
+    await navigateToTenant(page, tenantSlug, `/courses/${slug}`)
+    const enrollPanel = page.getByTestId('course-enroll-panel')
+    await expect(enrollPanel).toBeVisible({ timeout: 20_000 })
+    await expect(enrollPanel.getByRole('heading', { name: 'Enroll', exact: true })).toBeVisible()
+
+    const purchaseRes = await purchaseResponsePromise
+    const purchaseJson = (await purchaseRes.json()) as {
+      clientSecret?: string
+      stripeAccountId?: string
+    }
+    expect(purchaseJson.clientSecret).toMatch(/^pi_test_.*_secret_test$/)
+    expect(purchaseJson.stripeAccountId).toBe(connectAccountId)
+
+    await expect(page.getByTestId('stripe-not-configured')).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByText(/payment form not available in test mode/i)).toBeVisible()
+
+    const webhook = await postCoursePurchaseWebhook(request, {
+      connectAccountId,
+      userId,
+      tenantId,
+      courseId: course.id,
+      paymentIntentId: purchaseJson.clientSecret!.replace(/_secret_test$/, ''),
+    })
+    expect(webhook.status).toBe(200)
+
+    await expect
+      .poll(async () => {
+        const enrollments = await payload.find({
+          collection: 'course-enrollments',
+          where: {
+            and: [
+              { user: { equals: userId } },
+              { course: { equals: course.id } },
+              { status: { equals: 'active' } },
+            ],
+          },
+          limit: 1,
+          depth: 0,
+          overrideAccess: true,
+        })
+        return enrollments.totalDocs
+      }, { timeout: 15_000 })
+      .toBe(1)
+
+    const enrollment = (
+      await payload.find({
+        collection: 'course-enrollments',
+        where: {
+          and: [
+            { user: { equals: userId } },
+            { course: { equals: course.id } },
+          ],
+        },
+        limit: 1,
+        depth: 0,
+        overrideAccess: true,
+      })
+    ).docs[0] as { accessStartsAt?: string; accessEndsAt?: string; status?: string }
+
+    expect(enrollment.status).toBe('active')
+    expect(enrollment.accessStartsAt).toBeTruthy()
+    expect(enrollment.accessEndsAt).toBeTruthy()
+  })
+})

--- a/apps/atnd-me/tests/e2e/course-guest-enroll.e2e.spec.ts
+++ b/apps/atnd-me/tests/e2e/course-guest-enroll.e2e.spec.ts
@@ -1,0 +1,179 @@
+/**
+ * Guest enrolls from /courses/[slug]: name/email Continue → guest-checkout PI → webhook enrollment.
+ */
+import { test, expect } from './helpers/fixtures'
+import { navigateToTenant } from './helpers/subdomain-helpers'
+import { createTestEventType, getPayloadInstance } from './helpers/data-helpers'
+import { postCoursePurchaseWebhook } from './helpers/stripe-webhook-helpers'
+
+test.describe('Course guest enroll', () => {
+  test.describe.configure({ timeout: 120_000 })
+
+  test('guest continues to payment and webhook creates enrollment for guest user', async ({
+    page,
+    testData,
+    request,
+  }) => {
+    const payload = await getPayloadInstance()
+    const tenantId = testData.tenants[0]?.id
+    const tenantSlug = testData.tenants[0]?.slug
+    const w = testData.workerIndex
+    if (!tenantId || !tenantSlug) throw new Error('Tenant required')
+
+    const connectAccountId = `acct_e2e_connected_course_guest_${tenantId}_${w}`
+    await payload.update({
+      collection: 'tenants',
+      id: tenantId,
+      data: {
+        stripeConnectOnboardingStatus: 'active',
+        stripeConnectAccountId: connectAccountId,
+      },
+      overrideAccess: true,
+    })
+
+    const eventType = await createTestEventType(
+      tenantId,
+      'Course Guest Enroll Class',
+      8,
+      undefined,
+      w,
+    )
+    const slug = `e2e-course-guest-${w}-${Date.now()}`
+    const guestEmail = `course-guest-${w}-${Date.now()}@example.com`
+    const guestName = 'Sam Guest'
+
+    const course = (await payload.create({
+      collection: 'courses',
+      data: {
+        title: `E2E Guest Enroll Course w${w}`,
+        slug,
+        durationLength: 4,
+        durationUnit: 'weeks',
+        allowedEventTypes: [eventType.id],
+        status: 'open',
+        tenant: tenantId,
+        priceInformation: { price: 80 },
+      },
+      overrideAccess: true,
+      context: { skipStripeSync: true },
+    })) as { id: number }
+
+    await navigateToTenant(page, tenantSlug, `/courses/${slug}`)
+    await expect(page.getByTestId('course-enroll-panel')).toBeVisible({ timeout: 20_000 })
+
+    await page.getByTestId('course-guest-name').fill(guestName)
+    await page.getByTestId('course-guest-email').fill(guestEmail)
+
+    const guestCheckoutPromise = page.waitForResponse(
+      (res) =>
+        res.url().includes('/api/courses/guest-checkout') &&
+        res.request().method() === 'POST' &&
+        res.status() === 200,
+      { timeout: 30_000 },
+    )
+
+    await page.getByTestId('course-guest-checkout-continue').click()
+
+    const guestCheckoutRes = await guestCheckoutPromise
+    const guestJson = (await guestCheckoutRes.json()) as {
+      clientSecret?: string
+      stripeAccountId?: string
+    }
+    expect(guestJson.clientSecret).toMatch(/^pi_test_.*_secret_test$/)
+    expect(guestJson.stripeAccountId).toBe(connectAccountId)
+
+    await expect(page.getByTestId('stripe-not-configured')).toBeVisible({ timeout: 15_000 })
+
+    const guestUser = await payload.find({
+      collection: 'users',
+      where: { email: { equals: guestEmail } },
+      limit: 1,
+      depth: 0,
+      overrideAccess: true,
+    })
+    expect(guestUser.docs).toHaveLength(1)
+    const guestUserId = guestUser.docs[0]!.id as number
+
+    const webhook = await postCoursePurchaseWebhook(request, {
+      connectAccountId,
+      userId: guestUserId,
+      tenantId,
+      courseId: course.id,
+      paymentIntentId: guestJson.clientSecret!.replace(/_secret_test$/, ''),
+    })
+    expect(webhook.status).toBe(200)
+
+    await expect
+      .poll(async () => {
+        const enrollments = await payload.find({
+          collection: 'course-enrollments',
+          where: {
+            and: [
+              { user: { equals: guestUserId } },
+              { course: { equals: course.id } },
+              { status: { equals: 'active' } },
+            ],
+          },
+          limit: 1,
+          depth: 0,
+          overrideAccess: true,
+        })
+        return enrollments.totalDocs
+      }, { timeout: 15_000 })
+      .toBe(1)
+  })
+
+  test('guest cannot continue with incomplete email', async ({ page, testData }) => {
+    const payload = await getPayloadInstance()
+    const tenantId = testData.tenants[0]?.id
+    const tenantSlug = testData.tenants[0]?.slug
+    const w = testData.workerIndex
+    if (!tenantId || !tenantSlug) throw new Error('Tenant required')
+
+    await payload.update({
+      collection: 'tenants',
+      id: tenantId,
+      data: {
+        stripeConnectOnboardingStatus: 'active',
+        stripeConnectAccountId: `acct_e2e_connected_course_guest_val_${tenantId}_${w}`,
+      },
+      overrideAccess: true,
+    })
+
+    const eventType = await createTestEventType(
+      tenantId,
+      'Course Guest Validate Class',
+      8,
+      undefined,
+      w,
+    )
+    const slug = `e2e-course-guest-val-${w}-${Date.now()}`
+    await payload.create({
+      collection: 'courses',
+      data: {
+        title: `E2E Guest Validate Course w${w}`,
+        slug,
+        durationLength: 2,
+        durationUnit: 'weeks',
+        allowedEventTypes: [eventType.id],
+        status: 'open',
+        tenant: tenantId,
+        priceInformation: { price: 40 },
+      },
+      overrideAccess: true,
+      context: { skipStripeSync: true },
+    })
+
+    await navigateToTenant(page, tenantSlug, `/courses/${slug}`)
+    await expect(page.getByTestId('course-enroll-panel')).toBeVisible({ timeout: 20_000 })
+
+    await page.getByTestId('course-guest-name').fill('Sam')
+    await page.getByTestId('course-guest-email').fill('sam@ex')
+    await page.getByTestId('course-guest-checkout-continue').click()
+
+    await expect(
+      page.getByTestId('course-enroll-panel').getByRole('alert'),
+    ).toContainText(/complete email/i)
+    await expect(page.getByTestId('stripe-not-configured')).toHaveCount(0)
+  })
+})

--- a/apps/atnd-me/tests/e2e/course-guest-enroll.e2e.spec.ts
+++ b/apps/atnd-me/tests/e2e/course-guest-enroll.e2e.spec.ts
@@ -52,6 +52,7 @@ test.describe('Course guest enroll', () => {
         allowedEventTypes: [eventType.id],
         status: 'open',
         tenant: tenantId,
+        maxEnrollments: 2,
         priceInformation: { price: 80 },
       },
       overrideAccess: true,
@@ -60,6 +61,7 @@ test.describe('Course guest enroll', () => {
 
     await navigateToTenant(page, tenantSlug, `/courses/${slug}`)
     await expect(page.getByTestId('course-enroll-panel')).toBeVisible({ timeout: 20_000 })
+    await expect(page.getByTestId('course-places-remaining')).toContainText(/2 places left/i)
 
     await page.getByTestId('course-guest-name').fill(guestName)
     await page.getByTestId('course-guest-email').fill(guestEmail)
@@ -121,6 +123,11 @@ test.describe('Course guest enroll', () => {
         return enrollments.totalDocs
       }, { timeout: 15_000 })
       .toBe(1)
+
+    // Reload: capacity should drop after a successful purchase.
+    await navigateToTenant(page, tenantSlug, `/courses/${slug}`)
+    await expect(page.getByTestId('course-enroll-panel')).toBeVisible({ timeout: 20_000 })
+    await expect(page.getByTestId('course-places-remaining')).toContainText(/1 place left/i)
   })
 
   test('guest cannot continue with incomplete email', async ({ page, testData }) => {

--- a/apps/atnd-me/tests/e2e/courses-listing.e2e.spec.ts
+++ b/apps/atnd-me/tests/e2e/courses-listing.e2e.spec.ts
@@ -31,7 +31,35 @@ test.describe('Courses listing', () => {
         status: 'open',
         tenant: tenantId,
         priceInformation: { price: 75 },
-        about: 'Learn the fundamentals in six weeks.',
+        about: {
+          root: {
+            type: 'root',
+            format: '',
+            indent: 0,
+            version: 1,
+            direction: 'ltr',
+            children: [
+              {
+                type: 'paragraph',
+                format: '',
+                indent: 0,
+                version: 1,
+                direction: 'ltr',
+                children: [
+                  {
+                    type: 'text',
+                    detail: 0,
+                    format: 0,
+                    mode: 'normal',
+                    style: '',
+                    text: 'Learn the fundamentals in six weeks.',
+                    version: 1,
+                  },
+                ],
+              },
+            ],
+          },
+        },
       },
       overrideAccess: true,
       context: { skipStripeSync: true },

--- a/apps/atnd-me/tests/e2e/courses-listing.e2e.spec.ts
+++ b/apps/atnd-me/tests/e2e/courses-listing.e2e.spec.ts
@@ -1,0 +1,54 @@
+/**
+ * Courses listing + detail: open published courses appear on /courses; detail shows
+ * window copy and sticky enroll panel.
+ */
+import { test, expect } from './helpers/fixtures'
+import { navigateToTenant } from './helpers/subdomain-helpers'
+import { createTestEventType, getPayloadInstance } from './helpers/data-helpers'
+
+test.describe('Courses listing', () => {
+  test.describe.configure({ timeout: 60_000 })
+
+  test('/courses lists open course and detail shows enroll panel', async ({ page, testData }) => {
+    const payload = await getPayloadInstance()
+    const tenantId = testData.tenants[0]?.id
+    const tenantSlug = testData.tenants[0]?.slug
+    const w = testData.workerIndex
+    if (!tenantId || !tenantSlug) throw new Error('Tenant required')
+
+    const eventType = await createTestEventType(tenantId, 'Course Listing Class', 8, undefined, w)
+    const slug = `e2e-course-list-${w}-${Date.now()}`
+    const title = `E2E Open Course w${w} ${Date.now()}`
+
+    await payload.create({
+      collection: 'courses',
+      data: {
+        title,
+        slug,
+        durationLength: 6,
+        durationUnit: 'weeks',
+        allowedEventTypes: [eventType.id],
+        status: 'open',
+        tenant: tenantId,
+        priceInformation: { price: 75 },
+        about: 'Learn the fundamentals in six weeks.',
+      },
+      overrideAccess: true,
+      context: { skipStripeSync: true },
+    })
+
+    await navigateToTenant(page, tenantSlug, '/courses')
+    await page.waitForLoadState('domcontentloaded').catch(() => null)
+
+    await expect(page.getByRole('heading', { name: /^courses$/i })).toBeVisible({ timeout: 15000 })
+    const list = page.getByTestId('courses-list')
+    await expect(list).toBeVisible({ timeout: 15000 })
+    await expect(page.getByTestId('course-list-item').filter({ hasText: title })).toBeVisible()
+
+    await page.getByTestId('course-list-item').filter({ hasText: title }).click()
+    await expect(page).toHaveURL(new RegExp(`/courses/${slug}`))
+    await expect(page.getByRole('heading', { name: title })).toBeVisible({ timeout: 15000 })
+    await expect(page.getByTestId('course-enroll-panel')).toBeVisible()
+    await expect(page.getByText(/6 weeks from purchase|enroll/i).first()).toBeVisible()
+  })
+})

--- a/apps/atnd-me/tests/e2e/event-page-checkout-hold-release-on-leave.e2e.spec.ts
+++ b/apps/atnd-me/tests/e2e/event-page-checkout-hold-release-on-leave.e2e.spec.ts
@@ -418,7 +418,10 @@ test.describe('Event page: checkout hold release on leave (before card)', () => 
       )
       .toBeGreaterThanOrEqual(1)
 
-    await expect(page.getByTestId('stripe-not-configured').or(page.getByText(/payment methods/i).first())).toBeVisible({
+    // Test mode: mock PI — same signal as guest cases. Do not `.or()` with
+    // "Payment Methods" text; that heading can be visible at the same time and
+    // trips Playwright strict mode.
+    await expect(page.getByTestId('stripe-not-configured')).toBeVisible({
       timeout: 20_000,
     })
 

--- a/apps/atnd-me/tests/e2e/event-page-checkout-hold-release-on-leave.e2e.spec.ts
+++ b/apps/atnd-me/tests/e2e/event-page-checkout-hold-release-on-leave.e2e.spec.ts
@@ -1,0 +1,435 @@
+/**
+ * Regression: Event page checkout holds must release when the user leaves
+ * before entering card details (guest Continue, or auth drop-in bootstrap).
+ *
+ * These assert the production failure mode: hold is reserved, payment UI may
+ * show test/mock state (no card form), user navigates away → hold must be gone.
+ */
+import { test, expect } from './helpers/fixtures'
+import { navigateToTenant } from './helpers/subdomain-helpers'
+import { loginAsRegularUserViaApi } from './helpers/auth-helpers'
+import {
+  createTestEventType,
+  createTestPage,
+  createTestTimeslot,
+  getPayloadInstance,
+} from './helpers/data-helpers'
+
+async function countActiveHoldsForTimeslotUser(
+  payload: Awaited<ReturnType<typeof getPayloadInstance>>,
+  timeslotId: number,
+  userId: number,
+) {
+  const result = await payload.find({
+    collection: 'booking-checkout-holds' as import('payload').CollectionSlug,
+    where: {
+      and: [
+        { timeslot: { equals: timeslotId } },
+        { user: { equals: userId } },
+        { status: { equals: 'active' } },
+      ],
+    },
+    depth: 0,
+    limit: 20,
+    overrideAccess: true,
+  })
+  return result.totalDocs ?? 0
+}
+
+async function countActiveHoldsForTimeslot(
+  payload: Awaited<ReturnType<typeof getPayloadInstance>>,
+  timeslotId: number,
+) {
+  const result = await payload.find({
+    collection: 'booking-checkout-holds' as import('payload').CollectionSlug,
+    where: {
+      and: [{ timeslot: { equals: timeslotId } }, { status: { equals: 'active' } }],
+    },
+    depth: 0,
+    limit: 20,
+    overrideAccess: true,
+  })
+  return result.totalDocs ?? 0
+}
+
+async function seedEventPageWithDropIn(opts: {
+  tenantId: number
+  tenantSlug: string
+  workerIndex: number
+  label: string
+  places?: number
+}) {
+  const payload = await getPayloadInstance()
+  const { tenantId, workerIndex, label } = opts
+  const places = opts.places ?? 5
+
+  await payload.update({
+    collection: 'tenants',
+    id: tenantId,
+    data: {
+      stripeConnectOnboardingStatus: 'active',
+      stripeConnectAccountId: `acct_e2e_event_hold_${label}_${tenantId}_w${workerIndex}`,
+    },
+    overrideAccess: true,
+  })
+
+  const dropIn = (await payload.create({
+    collection: 'drop-ins',
+    data: {
+      name: `E2E Event Hold ${label} ${tenantId}-w${workerIndex}-${Date.now()}`,
+      isActive: true,
+      price: 15,
+      adjustable: true,
+      tenant: tenantId,
+    },
+    overrideAccess: true,
+  })) as { id: number }
+
+  const eventType = await createTestEventType(
+    tenantId,
+    `Event Hold ${label}`,
+    places,
+    undefined,
+    workerIndex,
+  )
+
+  await payload.update({
+    collection: 'event-types',
+    id: eventType.id,
+    data: {
+      paymentMethods: { allowedDropIn: dropIn.id },
+      tenant: tenantId,
+    },
+    overrideAccess: true,
+  })
+
+  const startTime = new Date()
+  startTime.setHours(18, 0, 0, 0)
+  startTime.setDate(startTime.getDate() + 2 + workerIndex)
+  const endTime = new Date(startTime)
+  endTime.setHours(19, 0, 0, 0)
+
+  const lesson = await createTestTimeslot(
+    tenantId,
+    eventType.id,
+    startTime,
+    endTime,
+    undefined,
+    true,
+  )
+
+  const pageSlug = `e2e-event-hold-${label}-w${workerIndex}-${Date.now()}`
+  await createTestPage(tenantId, pageSlug, `E2E Event Hold ${label}`, {
+    layout: [
+      {
+        blockType: 'event',
+        eventType: eventType.id,
+        timeslot: lesson.id,
+      },
+    ],
+  })
+
+  return {
+    payload,
+    lessonId: lesson.id as number,
+    pageSlug,
+    dropInId: dropIn.id,
+  }
+}
+
+test.describe('Event page: checkout hold release on leave (before card)', () => {
+  test.describe.configure({ timeout: 120_000 })
+
+  test('guest: leave after Continue (hold reserved, no card entry) releases hold', async ({
+    page,
+    testData,
+  }) => {
+    const tenant = testData.tenants[0]!
+    const workerIndex = testData.workerIndex
+    const { payload, lessonId, pageSlug } = await seedEventPageWithDropIn({
+      tenantId: tenant.id as number,
+      tenantSlug: tenant.slug,
+      workerIndex,
+      label: 'guest-continue',
+    })
+
+    const guestEmail = `event-hold-guest-${workerIndex}-${Date.now()}@example.com`
+    const guestName = 'Event Hold Guest'
+
+    await navigateToTenant(page, tenant.slug, `/${pageSlug}`)
+    await expect(page.getByTestId('event-ticket-panel')).toBeVisible({ timeout: 20_000 })
+
+    await page.locator('#guest-name').fill(guestName)
+    await page.locator('#guest-email').fill(guestEmail)
+
+    const reservePromise = page.waitForResponse(
+      (res) =>
+        res.url().includes('/api/events/guest-reserve-hold') &&
+        res.request().method() === 'POST' &&
+        res.status() === 200,
+      { timeout: 30_000 },
+    )
+
+    await page.getByTestId('guest-checkout-continue').click()
+    await reservePromise
+
+    // Hold exists; payment UI may still be bootstrapping — never interact with a card form.
+    await expect
+      .poll(() => countActiveHoldsForTimeslot(payload, lessonId), { timeout: 20_000 })
+      .toBeGreaterThanOrEqual(1)
+
+    // Soft leave before any Pay / card input (and while CheckoutForm may still upsert).
+    await navigateToTenant(page, tenant.slug, '/')
+    await page.waitForLoadState('domcontentloaded').catch(() => null)
+
+    await expect
+      .poll(() => countActiveHoldsForTimeslot(payload, lessonId), { timeout: 25_000 })
+      .toBe(0)
+  })
+
+  test('guest: leave after payment UI ready (still no card) releases hold', async ({
+    page,
+    testData,
+  }) => {
+    const tenant = testData.tenants[0]!
+    const workerIndex = testData.workerIndex
+    const { payload, lessonId, pageSlug } = await seedEventPageWithDropIn({
+      tenantId: tenant.id as number,
+      tenantSlug: tenant.slug,
+      workerIndex,
+      label: 'guest-ready',
+    })
+
+    const guestEmail = `event-hold-guest-ready-${workerIndex}-${Date.now()}@example.com`
+
+    await navigateToTenant(page, tenant.slug, `/${pageSlug}`)
+    await expect(page.getByTestId('event-ticket-panel')).toBeVisible({ timeout: 20_000 })
+
+    await page.locator('#guest-name').fill('Ready Guest')
+    await page.locator('#guest-email').fill(guestEmail)
+
+    const guestCheckoutPromise = page.waitForResponse(
+      (res) =>
+        res.url().includes('/api/events/guest-checkout') &&
+        res.request().method() === 'POST' &&
+        res.status() === 200,
+      { timeout: 30_000 },
+    )
+
+    await page.getByTestId('guest-checkout-continue').click()
+    await guestCheckoutPromise
+
+    // Test mode: mock PI → no Stripe card element. Hold must still release on leave.
+    await expect(page.getByTestId('stripe-not-configured')).toBeVisible({ timeout: 15_000 })
+
+    const guestUser = await payload.find({
+      collection: 'users',
+      where: { email: { equals: guestEmail } },
+      limit: 1,
+      depth: 0,
+      overrideAccess: true,
+    })
+    expect(guestUser.docs).toHaveLength(1)
+    const guestUserId = guestUser.docs[0]!.id as number
+
+    await expect
+      .poll(
+        () => countActiveHoldsForTimeslotUser(payload, lessonId, guestUserId),
+        { timeout: 20_000 },
+      )
+      .toBeGreaterThanOrEqual(1)
+
+    await navigateToTenant(page, tenant.slug, '/')
+    await page.waitForLoadState('domcontentloaded').catch(() => null)
+
+    await expect
+      .poll(
+        () => countActiveHoldsForTimeslotUser(payload, lessonId, guestUserId),
+        { timeout: 25_000 },
+      )
+      .toBe(0)
+  })
+
+  test('guest: late upsert after tab close must not leave capacity held', async ({
+    browser,
+    testData,
+    request,
+  }) => {
+    const tenant = testData.tenants[0]!
+    const workerIndex = testData.workerIndex
+    const { payload, lessonId, pageSlug } = await seedEventPageWithDropIn({
+      tenantId: tenant.id as number,
+      tenantSlug: tenant.slug,
+      workerIndex,
+      label: 'guest-late-upsert',
+    })
+
+    const guestEmail = `event-hold-late-${workerIndex}-${Date.now()}@example.com`
+    const guestName = 'Late Upsert Guest'
+    const context = await browser.newContext()
+    const page = await context.newPage()
+
+    try {
+      await navigateToTenant(page, tenant.slug, `/${pageSlug}`)
+      await expect(page.getByTestId('event-ticket-panel')).toBeVisible({ timeout: 20_000 })
+
+      await page.locator('#guest-name').fill(guestName)
+      await page.locator('#guest-email').fill(guestEmail)
+
+      const reservePromise = page.waitForResponse(
+        (res) =>
+          res.url().includes('/api/events/guest-reserve-hold') &&
+          res.request().method() === 'POST' &&
+          res.status() === 200,
+        { timeout: 30_000 },
+      )
+
+      await page.getByTestId('guest-checkout-continue').click()
+      await reservePromise
+
+      await expect
+        .poll(() => countActiveHoldsForTimeslot(payload, lessonId), { timeout: 20_000 })
+        .toBeGreaterThanOrEqual(1)
+
+      const activeHold = await payload.find({
+        collection: 'booking-checkout-holds' as import('payload').CollectionSlug,
+        where: {
+          and: [
+            { timeslot: { equals: lessonId } },
+            { status: { equals: 'active' } },
+          ],
+        },
+        limit: 1,
+        depth: 0,
+        overrideAccess: true,
+      })
+      const checkoutSessionId = (activeHold.docs[0] as { checkoutSessionId?: string | null } | undefined)
+        ?.checkoutSessionId
+      expect(checkoutSessionId).toBeTruthy()
+
+      await page.close()
+
+      // Unload release should clear the hold first.
+      await expect
+        .poll(() => countActiveHoldsForTimeslot(payload, lessonId), { timeout: 25_000 })
+        .toBe(0)
+
+      // Simulate a late in-flight upsert for the same checkout session after the tab is gone.
+      const lateUpsert = await request.post('http://127.0.0.1:3000/api/events/guest-reserve-hold', {
+        headers: { Host: `${tenant.slug}.localhost:3000` },
+        data: {
+          timeslotId: lessonId,
+          quantity: 1,
+          guestName,
+          guestEmail,
+          checkoutSessionId,
+        },
+        failOnStatusCode: false,
+      })
+      expect(lateUpsert.status()).toBe(200)
+      const lateJson = (await lateUpsert.json()) as { abandoned?: boolean; holdId?: number | null }
+      expect(lateJson.abandoned).toBe(true)
+
+      await expect
+        .poll(() => countActiveHoldsForTimeslot(payload, lessonId), { timeout: 10_000 })
+        .toBe(0)
+    } finally {
+      await context.close().catch(() => null)
+    }
+  })
+
+  test('guest: closing the tab after Continue (no card entry) releases hold', async ({
+    browser,
+    testData,
+  }) => {
+    const tenant = testData.tenants[0]!
+    const workerIndex = testData.workerIndex
+    const { payload, lessonId, pageSlug } = await seedEventPageWithDropIn({
+      tenantId: tenant.id as number,
+      tenantSlug: tenant.slug,
+      workerIndex,
+      label: 'guest-tabclose',
+    })
+
+    const guestEmail = `event-hold-tabclose-${workerIndex}-${Date.now()}@example.com`
+    const context = await browser.newContext()
+    const page = await context.newPage()
+
+    try {
+      await navigateToTenant(page, tenant.slug, `/${pageSlug}`)
+      await expect(page.getByTestId('event-ticket-panel')).toBeVisible({ timeout: 20_000 })
+
+      await page.locator('#guest-name').fill('Tab Close Guest')
+      await page.locator('#guest-email').fill(guestEmail)
+
+      const reservePromise = page.waitForResponse(
+        (res) =>
+          res.url().includes('/api/events/guest-reserve-hold') &&
+          res.request().method() === 'POST' &&
+          res.status() === 200,
+        { timeout: 30_000 },
+      )
+
+      await page.getByTestId('guest-checkout-continue').click()
+      await reservePromise
+
+      await expect
+        .poll(() => countActiveHoldsForTimeslot(payload, lessonId), { timeout: 20_000 })
+        .toBeGreaterThanOrEqual(1)
+
+      // Hard exit (tab close) — relies on pagehide/beforeunload + beacon/XHR, not React cleanup.
+      await page.close()
+
+      await expect
+        .poll(() => countActiveHoldsForTimeslot(payload, lessonId), { timeout: 25_000 })
+        .toBe(0)
+    } finally {
+      await context.close().catch(() => null)
+    }
+  })
+
+  test('authenticated: leave after drop-in hold reserved (no card entry) releases hold', async ({
+    page,
+    testData,
+  }) => {
+    const tenant = testData.tenants[0]!
+    const user = testData.users.user1
+    const workerIndex = testData.workerIndex
+    const { payload, lessonId, pageSlug } = await seedEventPageWithDropIn({
+      tenantId: tenant.id as number,
+      tenantSlug: tenant.slug,
+      workerIndex,
+      label: 'auth',
+    })
+
+    await loginAsRegularUserViaApi(page, user.email, 'password', {
+      tenantSlug: tenant.slug,
+    })
+
+    await navigateToTenant(page, tenant.slug, `/${pageSlug}`)
+    await expect(page.getByTestId('event-ticket-panel')).toBeVisible({ timeout: 20_000 })
+
+    // Auth checkout bootstraps a hold when PaymentMethods / CheckoutForm mounts.
+    // In test mode there is no card form — leave before any Pay click.
+    await expect
+      .poll(
+        () => countActiveHoldsForTimeslotUser(payload, lessonId, user.id as number),
+        { timeout: 30_000 },
+      )
+      .toBeGreaterThanOrEqual(1)
+
+    await expect(page.getByTestId('stripe-not-configured').or(page.getByText(/payment methods/i).first())).toBeVisible({
+      timeout: 20_000,
+    })
+
+    await navigateToTenant(page, tenant.slug, '/')
+    await page.waitForLoadState('domcontentloaded').catch(() => null)
+
+    await expect
+      .poll(
+        () => countActiveHoldsForTimeslotUser(payload, lessonId, user.id as number),
+        { timeout: 25_000 },
+      )
+      .toBe(0)
+  })
+})

--- a/apps/atnd-me/tests/e2e/event-page-checkout-hold-release-on-leave.e2e.spec.ts
+++ b/apps/atnd-me/tests/e2e/event-page-checkout-hold-release-on-leave.e2e.spec.ts
@@ -307,7 +307,8 @@ test.describe('Event page: checkout hold release on leave (before card)', () => 
         ?.checkoutSessionId
       expect(checkoutSessionId).toBeTruthy()
 
-      await page.close()
+      // Default page.close() skips unload handlers — release listeners never run.
+      await page.close({ runBeforeUnload: true })
 
       // Unload release should clear the hold first.
       await expect
@@ -377,8 +378,9 @@ test.describe('Event page: checkout hold release on leave (before card)', () => 
         .poll(() => countActiveHoldsForTimeslot(payload, lessonId), { timeout: 20_000 })
         .toBeGreaterThanOrEqual(1)
 
-      // Hard exit (tab close) — relies on pagehide/beforeunload + beacon/XHR, not React cleanup.
-      await page.close()
+      // Hard exit (tab close) — production uses pagehide/beforeunload + beacon/XHR.
+      // Playwright's default page.close() skips unload handlers; run them explicitly.
+      await page.close({ runBeforeUnload: true })
 
       await expect
         .poll(() => countActiveHoldsForTimeslot(payload, lessonId), { timeout: 25_000 })

--- a/apps/atnd-me/tests/e2e/event-page-purchase.e2e.spec.ts
+++ b/apps/atnd-me/tests/e2e/event-page-purchase.e2e.spec.ts
@@ -1,0 +1,374 @@
+/**
+ * Event page ticket purchase: guest (1 + multi) and authenticated drop-in →
+ * mock PaymentIntent → signed webhook fulfills checkout hold → confirmed bookings.
+ */
+import { test, expect } from './helpers/fixtures'
+import { navigateToTenant } from './helpers/subdomain-helpers'
+import { loginAsRegularUserViaApi } from './helpers/auth-helpers'
+import {
+  createTestEventType,
+  createTestPage,
+  createTestTimeslot,
+  getPayloadInstance,
+} from './helpers/data-helpers'
+import { postHoldFulfillmentWebhook } from './helpers/stripe-webhook-helpers'
+
+async function seedEventPageWithDropIn(opts: {
+  tenantId: number
+  workerIndex: number
+  label: string
+  places?: number
+  connectAccountId: string
+}) {
+  const payload = await getPayloadInstance()
+  const { tenantId, workerIndex, label, connectAccountId } = opts
+  const places = opts.places ?? 8
+
+  await payload.update({
+    collection: 'tenants',
+    id: tenantId,
+    data: {
+      stripeConnectOnboardingStatus: 'active',
+      stripeConnectAccountId: connectAccountId,
+    },
+    overrideAccess: true,
+  })
+
+  const dropIn = (await payload.create({
+    collection: 'drop-ins',
+    data: {
+      name: `E2E Event Purchase ${label} ${tenantId}-w${workerIndex}-${Date.now()}`,
+      isActive: true,
+      price: 15,
+      adjustable: true,
+      tenant: tenantId,
+    },
+    overrideAccess: true,
+  })) as { id: number }
+
+  const eventType = await createTestEventType(
+    tenantId,
+    `Event Purchase ${label}`,
+    places,
+    undefined,
+    workerIndex,
+  )
+
+  await payload.update({
+    collection: 'event-types',
+    id: eventType.id,
+    data: {
+      paymentMethods: { allowedDropIn: dropIn.id },
+      tenant: tenantId,
+    },
+    overrideAccess: true,
+  })
+
+  const startTime = new Date()
+  startTime.setHours(18, 0, 0, 0)
+  startTime.setDate(startTime.getDate() + 3 + workerIndex)
+  const endTime = new Date(startTime)
+  endTime.setHours(19, 0, 0, 0)
+
+  const lesson = await createTestTimeslot(
+    tenantId,
+    eventType.id,
+    startTime,
+    endTime,
+    undefined,
+    true,
+  )
+
+  const pageSlug = `e2e-event-purchase-${label}-w${workerIndex}-${Date.now()}`
+  await createTestPage(tenantId, pageSlug, `E2E Event Purchase ${label}`, {
+    layout: [
+      {
+        blockType: 'event',
+        eventType: eventType.id,
+        timeslot: lesson.id,
+      },
+    ],
+  })
+
+  return {
+    payload,
+    lessonId: lesson.id as number,
+    pageSlug,
+    dropInId: dropIn.id,
+  }
+}
+
+async function countConfirmedBookingsForUserTimeslot(
+  payload: Awaited<ReturnType<typeof getPayloadInstance>>,
+  timeslotId: number,
+  userId: number,
+) {
+  const result = await payload.find({
+    collection: 'bookings',
+    where: {
+      and: [
+        { timeslot: { equals: timeslotId } },
+        { user: { equals: userId } },
+        { status: { equals: 'confirmed' } },
+      ],
+    },
+    depth: 0,
+    limit: 50,
+    overrideAccess: true,
+  })
+  return result.totalDocs ?? 0
+}
+
+async function findActiveHoldId(
+  payload: Awaited<ReturnType<typeof getPayloadInstance>>,
+  timeslotId: number,
+  userId: number,
+): Promise<number | null> {
+  const result = await payload.find({
+    collection: 'booking-checkout-holds' as import('payload').CollectionSlug,
+    where: {
+      and: [
+        { timeslot: { equals: timeslotId } },
+        { user: { equals: userId } },
+        { status: { equals: 'active' } },
+      ],
+    },
+    depth: 0,
+    limit: 1,
+    overrideAccess: true,
+  })
+  const id = result.docs[0]?.id
+  return typeof id === 'number' ? id : null
+}
+
+test.describe('Event page: ticket purchase', () => {
+  test.describe.configure({ timeout: 120_000 })
+
+  test('guest purchases 1 ticket via Continue → mock PI → webhook → confirmed booking', async ({
+    page,
+    testData,
+    request,
+  }) => {
+    const tenant = testData.tenants[0]!
+    const workerIndex = testData.workerIndex
+    const connectAccountId = `acct_e2e_event_buy_1_${tenant.id}_w${workerIndex}`
+    const { payload, lessonId, pageSlug } = await seedEventPageWithDropIn({
+      tenantId: tenant.id as number,
+      workerIndex,
+      label: 'guest-1',
+      connectAccountId,
+    })
+
+    const guestEmail = `event-buy-1-${workerIndex}-${Date.now()}@example.com`
+    const guestName = 'Event Buyer One'
+
+    await navigateToTenant(page, tenant.slug, `/${pageSlug}`)
+    await expect(page.getByTestId('event-ticket-panel')).toBeVisible({ timeout: 20_000 })
+    await expect(page.getByTestId('event-places-remaining')).toContainText(/places left|place left/i)
+
+    await page.locator('#guest-name').fill(guestName)
+    await page.locator('#guest-email').fill(guestEmail)
+
+    const reservePromise = page.waitForResponse(
+      (res) =>
+        res.url().includes('/api/events/guest-reserve-hold') &&
+        res.request().method() === 'POST' &&
+        res.status() === 200,
+      { timeout: 30_000 },
+    )
+    const checkoutPromise = page.waitForResponse(
+      (res) =>
+        res.url().includes('/api/events/guest-checkout') &&
+        res.request().method() === 'POST' &&
+        res.status() === 200,
+      { timeout: 30_000 },
+    )
+
+    await page.getByTestId('guest-checkout-continue').click()
+    await reservePromise
+    const checkoutRes = await checkoutPromise
+    const checkoutJson = (await checkoutRes.json()) as {
+      clientSecret?: string
+      holdId?: number
+      stripeAccountId?: string
+    }
+
+    expect(checkoutJson.clientSecret).toMatch(/^pi_test_.*_secret_test$/)
+    expect(checkoutJson.holdId).toEqual(expect.any(Number))
+    expect(checkoutJson.stripeAccountId).toBe(connectAccountId)
+    await expect(page.getByTestId('stripe-not-configured')).toBeVisible({ timeout: 15_000 })
+
+    const guestUser = await payload.find({
+      collection: 'users',
+      where: { email: { equals: guestEmail } },
+      limit: 1,
+      depth: 0,
+      overrideAccess: true,
+    })
+    expect(guestUser.docs).toHaveLength(1)
+    const guestUserId = guestUser.docs[0]!.id as number
+
+    const webhook = await postHoldFulfillmentWebhook(request, {
+      connectAccountId,
+      userId: guestUserId,
+      tenantId: tenant.id as number,
+      holdId: checkoutJson.holdId!,
+      timeslotId: lessonId,
+      quantity: 1,
+      paymentIntentId: checkoutJson.clientSecret!.replace(/_secret_test$/, ''),
+    })
+    expect(webhook.status).toBe(200)
+
+    await expect
+      .poll(() => countConfirmedBookingsForUserTimeslot(payload, lessonId, guestUserId), {
+        timeout: 15_000,
+      })
+      .toBe(1)
+  })
+
+  test('guest purchases 2 tickets via quantity selector → webhook → 2 confirmed bookings', async ({
+    page,
+    testData,
+    request,
+  }) => {
+    const tenant = testData.tenants[0]!
+    const workerIndex = testData.workerIndex
+    const connectAccountId = `acct_e2e_event_buy_2_${tenant.id}_w${workerIndex}`
+    const { payload, lessonId, pageSlug } = await seedEventPageWithDropIn({
+      tenantId: tenant.id as number,
+      workerIndex,
+      label: 'guest-2',
+      places: 5,
+      connectAccountId,
+    })
+
+    const guestEmail = `event-buy-2-${workerIndex}-${Date.now()}@example.com`
+
+    await navigateToTenant(page, tenant.slug, `/${pageSlug}`)
+    await expect(page.getByTestId('event-ticket-panel')).toBeVisible({ timeout: 20_000 })
+
+    const increaseQty = page.getByRole('button', { name: /increase quantity/i }).first()
+    await expect(increaseQty).toBeVisible({ timeout: 10_000 })
+    await increaseQty.click()
+
+    await page.locator('#guest-name').fill('Event Buyer Two')
+    await page.locator('#guest-email').fill(guestEmail)
+
+    const reservePromise = page.waitForResponse(
+      (res) =>
+        res.url().includes('/api/events/guest-reserve-hold') &&
+        res.request().method() === 'POST' &&
+        res.status() === 200,
+      { timeout: 30_000 },
+    )
+    const checkoutPromise = page.waitForResponse(
+      (res) =>
+        res.url().includes('/api/events/guest-checkout') &&
+        res.request().method() === 'POST' &&
+        res.status() === 200,
+      { timeout: 30_000 },
+    )
+
+    await page.getByTestId('guest-checkout-continue').click()
+    const reserveRes = await reservePromise
+    const reserveJson = (await reserveRes.json()) as { quantity?: number; holdId?: number }
+    expect(reserveJson.quantity).toBe(2)
+
+    const checkoutRes = await checkoutPromise
+    const checkoutJson = (await checkoutRes.json()) as {
+      clientSecret?: string
+      holdId?: number
+    }
+    expect(checkoutJson.holdId).toEqual(expect.any(Number))
+    await expect(page.getByTestId('stripe-not-configured')).toBeVisible({ timeout: 15_000 })
+
+    const guestUser = await payload.find({
+      collection: 'users',
+      where: { email: { equals: guestEmail } },
+      limit: 1,
+      depth: 0,
+      overrideAccess: true,
+    })
+    const guestUserId = guestUser.docs[0]!.id as number
+
+    const webhook = await postHoldFulfillmentWebhook(request, {
+      connectAccountId,
+      userId: guestUserId,
+      tenantId: tenant.id as number,
+      holdId: checkoutJson.holdId!,
+      timeslotId: lessonId,
+      quantity: 2,
+      paymentIntentId: checkoutJson.clientSecret!.replace(/_secret_test$/, ''),
+    })
+    expect(webhook.status).toBe(200)
+
+    await expect
+      .poll(() => countConfirmedBookingsForUserTimeslot(payload, lessonId, guestUserId), {
+        timeout: 15_000,
+      })
+      .toBe(2)
+  })
+
+  test('authenticated user purchases 1 ticket via drop-in → webhook → confirmed booking', async ({
+    page,
+    testData,
+    request,
+  }) => {
+    const tenant = testData.tenants[0]!
+    const user = testData.users.user1
+    const workerIndex = testData.workerIndex
+    const connectAccountId = `acct_e2e_event_buy_auth_${tenant.id}_w${workerIndex}`
+    const { payload, lessonId, pageSlug } = await seedEventPageWithDropIn({
+      tenantId: tenant.id as number,
+      workerIndex,
+      label: 'auth-1',
+      connectAccountId,
+    })
+
+    await loginAsRegularUserViaApi(page, user.email, 'password', {
+      request,
+      tenantSlug: tenant.slug,
+    })
+
+    const paymentIntentPromise = page.waitForResponse(
+      (res) =>
+        res.url().includes('/api/stripe/connect/create-payment-intent') &&
+        res.request().method() === 'POST' &&
+        res.status() === 200,
+      { timeout: 45_000 },
+    )
+
+    await navigateToTenant(page, tenant.slug, `/${pageSlug}`)
+    await expect(page.getByTestId('event-ticket-panel')).toBeVisible({ timeout: 20_000 })
+
+    const paymentIntentRes = await paymentIntentPromise
+    const paymentIntentJson = (await paymentIntentRes.json()) as { clientSecret?: string }
+    expect(paymentIntentJson.clientSecret).toMatch(/^pi_test_.*_secret_test$/)
+    await expect(page.getByTestId('stripe-not-configured')).toBeVisible({ timeout: 15_000 })
+
+    await expect
+      .poll(() => findActiveHoldId(payload, lessonId, user.id as number), { timeout: 20_000 })
+      .not.toBeNull()
+
+    const resolvedHoldId = await findActiveHoldId(payload, lessonId, user.id as number)
+    expect(resolvedHoldId).toEqual(expect.any(Number))
+
+    const webhook = await postHoldFulfillmentWebhook(request, {
+      connectAccountId,
+      userId: user.id as number,
+      tenantId: tenant.id as number,
+      holdId: resolvedHoldId!,
+      timeslotId: lessonId,
+      quantity: 1,
+      paymentIntentId: paymentIntentJson.clientSecret!.replace(/_secret_test$/, ''),
+    })
+    expect(webhook.status).toBe(200)
+
+    await expect
+      .poll(
+        () => countConfirmedBookingsForUserTimeslot(payload, lessonId, user.id as number),
+        { timeout: 15_000 },
+      )
+      .toBe(1)
+  })
+})

--- a/apps/atnd-me/tests/e2e/helpers/stripe-webhook-helpers.ts
+++ b/apps/atnd-me/tests/e2e/helpers/stripe-webhook-helpers.ts
@@ -23,14 +23,17 @@ export function signStripeWebhookBody(body: string, secret = webhookSecret()): s
   return `t=${t},v1=${v1}`
 }
 
-function coursePurchasePaymentIntentEvent(args: {
+function paymentIntentSucceededEvent(args: {
   id: string
   account: string
   paymentIntentId: string
   metadata: Record<string, string>
+  amount?: number
+  requestId?: string
 }) {
   const apiVersion =
     process.env.STRIPE_API_VERSION?.trim() || '2026-02-25.clover'
+  const amount = args.amount ?? 7500
   return {
     id: args.id,
     object: 'event' as const,
@@ -40,9 +43,9 @@ function coursePurchasePaymentIntentEvent(args: {
       object: {
         id: args.paymentIntentId,
         object: 'payment_intent' as const,
-        amount: 7500,
-        amount_received: 7500,
-        application_fee_amount: 225,
+        amount,
+        amount_received: amount,
+        application_fee_amount: Math.max(1, Math.round(amount * 0.03)),
         currency: 'eur',
         customer: null,
         livemode: false,
@@ -53,10 +56,26 @@ function coursePurchasePaymentIntentEvent(args: {
     },
     livemode: false,
     pending_webhooks: 0,
-    request: { id: 'req_e2e_course', idempotency_key: null },
+    request: { id: args.requestId ?? 'req_e2e', idempotency_key: null },
     type: 'payment_intent.succeeded' as const,
     account: args.account,
   }
+}
+
+async function postSignedWebhook(
+  request: APIRequestContext,
+  event: unknown,
+): Promise<{ status: number; body: unknown }> {
+  const body = JSON.stringify(event)
+  const res = await request.post(`${BASE_URL}/api/stripe/webhook`, {
+    headers: {
+      'content-type': 'application/json',
+      'stripe-signature': signStripeWebhookBody(body),
+    },
+    data: body,
+  })
+  const json = await res.json().catch(() => ({}))
+  return { status: res.status(), body: json }
 }
 
 export async function postCoursePurchaseWebhook(
@@ -72,10 +91,11 @@ export async function postCoursePurchaseWebhook(
 ): Promise<{ status: number; body: unknown }> {
   const paymentIntentId =
     args.paymentIntentId ?? `pi_e2e_course_${args.courseId}_${Date.now()}`
-  const event = coursePurchasePaymentIntentEvent({
+  const event = paymentIntentSucceededEvent({
     id: args.eventId ?? `evt_e2e_course_${Date.now()}`,
     account: args.connectAccountId,
     paymentIntentId,
+    requestId: 'req_e2e_course',
     metadata: {
       type: 'course_purchase',
       userId: String(args.userId),
@@ -83,14 +103,41 @@ export async function postCoursePurchaseWebhook(
       courseId: String(args.courseId),
     },
   })
-  const body = JSON.stringify(event)
-  const res = await request.post(`${BASE_URL}/api/stripe/webhook`, {
-    headers: {
-      'content-type': 'application/json',
-      'stripe-signature': signStripeWebhookBody(body),
+  return postSignedWebhook(request, event)
+}
+
+/**
+ * Simulate payment_intent.succeeded for an event/drop-in checkout hold.
+ * Webhook fulfills the hold into confirmed bookings (same path as live Stripe).
+ */
+export async function postHoldFulfillmentWebhook(
+  request: APIRequestContext,
+  args: {
+    connectAccountId: string
+    userId: number
+    tenantId: number
+    holdId: number
+    paymentIntentId?: string
+    eventId?: string
+    timeslotId?: number
+    quantity?: number
+  },
+): Promise<{ status: number; body: unknown }> {
+  const paymentIntentId =
+    args.paymentIntentId ?? `pi_e2e_hold_${args.holdId}_${Date.now()}`
+  const event = paymentIntentSucceededEvent({
+    id: args.eventId ?? `evt_e2e_hold_${Date.now()}`,
+    account: args.connectAccountId,
+    paymentIntentId,
+    requestId: 'req_e2e_hold',
+    amount: Math.max(100, (args.quantity ?? 1) * 1500),
+    metadata: {
+      userId: String(args.userId),
+      tenantId: String(args.tenantId),
+      holdId: String(args.holdId),
+      ...(args.timeslotId != null ? { timeslotId: String(args.timeslotId) } : {}),
+      ...(args.quantity != null ? { quantity: String(args.quantity) } : {}),
     },
-    data: body,
   })
-  const json = await res.json().catch(() => ({}))
-  return { status: res.status(), body: json }
+  return postSignedWebhook(request, event)
 }

--- a/apps/atnd-me/tests/e2e/helpers/stripe-webhook-helpers.ts
+++ b/apps/atnd-me/tests/e2e/helpers/stripe-webhook-helpers.ts
@@ -1,0 +1,96 @@
+/**
+ * Helpers to simulate Stripe Connect webhook delivery in Playwright e2e.
+ */
+import { createHmac } from 'node:crypto'
+import type { APIRequestContext } from '@playwright/test'
+import { BASE_URL } from './auth-helpers'
+
+function webhookSecret(): string {
+  const secret =
+    process.env.STRIPE_CONNECT_WEBHOOK_SECRET?.trim() ||
+    process.env.STRIPE_WEBHOOK_SECRET?.trim()
+  if (!secret) {
+    throw new Error(
+      'STRIPE_CONNECT_WEBHOOK_SECRET (or STRIPE_WEBHOOK_SECRET) is required to sign e2e webhooks',
+    )
+  }
+  return secret
+}
+
+export function signStripeWebhookBody(body: string, secret = webhookSecret()): string {
+  const t = Math.floor(Date.now() / 1000)
+  const v1 = createHmac('sha256', secret).update(`${t}.${body}`).digest('hex')
+  return `t=${t},v1=${v1}`
+}
+
+function coursePurchasePaymentIntentEvent(args: {
+  id: string
+  account: string
+  paymentIntentId: string
+  metadata: Record<string, string>
+}) {
+  const apiVersion =
+    process.env.STRIPE_API_VERSION?.trim() || '2026-02-25.clover'
+  return {
+    id: args.id,
+    object: 'event' as const,
+    api_version: apiVersion,
+    created: Math.floor(Date.now() / 1000),
+    data: {
+      object: {
+        id: args.paymentIntentId,
+        object: 'payment_intent' as const,
+        amount: 7500,
+        amount_received: 7500,
+        application_fee_amount: 225,
+        currency: 'eur',
+        customer: null,
+        livemode: false,
+        metadata: args.metadata,
+        status: 'succeeded' as const,
+        transfer_data: { destination: args.account },
+      },
+    },
+    livemode: false,
+    pending_webhooks: 0,
+    request: { id: 'req_e2e_course', idempotency_key: null },
+    type: 'payment_intent.succeeded' as const,
+    account: args.account,
+  }
+}
+
+export async function postCoursePurchaseWebhook(
+  request: APIRequestContext,
+  args: {
+    connectAccountId: string
+    userId: number
+    tenantId: number
+    courseId: number
+    paymentIntentId?: string
+    eventId?: string
+  },
+): Promise<{ status: number; body: unknown }> {
+  const paymentIntentId =
+    args.paymentIntentId ?? `pi_e2e_course_${args.courseId}_${Date.now()}`
+  const event = coursePurchasePaymentIntentEvent({
+    id: args.eventId ?? `evt_e2e_course_${Date.now()}`,
+    account: args.connectAccountId,
+    paymentIntentId,
+    metadata: {
+      type: 'course_purchase',
+      userId: String(args.userId),
+      tenantId: String(args.tenantId),
+      courseId: String(args.courseId),
+    },
+  })
+  const body = JSON.stringify(event)
+  const res = await request.post(`${BASE_URL}/api/stripe/webhook`, {
+    headers: {
+      'content-type': 'application/json',
+      'stripe-signature': signStripeWebhookBody(body),
+    },
+    data: body,
+  })
+  const json = await res.json().catch(() => ({}))
+  return { status: res.status(), body: json }
+}

--- a/apps/atnd-me/tests/e2e/schedule-immediate-booking.e2e.spec.ts
+++ b/apps/atnd-me/tests/e2e/schedule-immediate-booking.e2e.spec.ts
@@ -9,7 +9,7 @@
  * Stories:
  *  1. No payment methods → immediate booking, button becomes "Modify Booking"
  *  2. Active subscription → immediate booking, button becomes "Cancel Booking" when single-slot
- *  3. Valid class pass → immediate booking (1 credit deducted), button becomes "Modify Booking"
+ *  3. Valid class pass → immediate booking (1 credit deducted), button becomes "Cancel Booking" when single-slot
  *  4. Payment required (no entitlement) → redirect to /bookings/[id]
  *  5. Subscription limit reached → redirect to /bookings/[id]
  *  5b. 2x/week limit exhausted (3rd check-in) → redirect to /bookings/[id], Membership tab
@@ -228,7 +228,7 @@ test.describe('Schedule immediate booking', () => {
 
   // ── Story 3: Valid class pass → immediate booking ─────────────────────────────
 
-  test('valid class pass: Book creates confirmed booking, decrements 1 credit, button becomes Modify Booking', async ({
+  test('valid class pass: Book creates confirmed booking, decrements 1 credit, button becomes Cancel Booking', async ({
     page,
     testData,
   }) => {
@@ -306,9 +306,11 @@ test.describe('Schedule immediate booking', () => {
     )
     await Promise.all([trpcCall, bookBtn.click()])
 
-    // Button should become "Modify Booking"
+    // Single-slot class pass caps: public schedule can only cancel, not increase quantity.
+    const cancelBtn = await getLessonBookButton(page, scheduleTitle, /cancel booking/i)
+    await expect(cancelBtn).toBeVisible({ timeout: 15000 })
     const modifyBtn = await getLessonBookButton(page, scheduleTitle, /modify booking/i)
-    await expect(modifyBtn).toBeVisible({ timeout: 15000 })
+    await expect(modifyBtn).not.toBeVisible({ timeout: 5000 })
 
     // URL should remain on schedule
     await page.waitForTimeout(300)

--- a/apps/atnd-me/tests/int/course-purchase-enrollment.int.spec.ts
+++ b/apps/atnd-me/tests/int/course-purchase-enrollment.int.spec.ts
@@ -1,0 +1,375 @@
+/**
+ * Course purchase via payment_intent.succeeded: creates enrollment with stamped access window.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest'
+
+vi.mock('@/lib/stripe-connect/webhookVerify', () => ({
+  verifyStripeConnectWebhook: vi.fn(),
+}))
+vi.mock('@/lib/stripe-connect/webhookProcessed', () => ({
+  hasProcessedStripeConnectEvent: vi.fn(),
+  markStripeConnectEventProcessed: vi.fn(),
+}))
+
+import { getPayload, type Payload } from 'payload'
+import config from '@/payload.config'
+import { NextRequest } from 'next/server'
+import { POST } from '@/app/api/stripe/webhook/route'
+import * as webhookVerify from '@/lib/stripe-connect/webhookVerify'
+import * as webhookProcessed from '@/lib/stripe-connect/webhookProcessed'
+import {
+  createPaymentIntentSucceededEvent,
+  createCheckoutSessionCompletedEvent,
+} from '../helpers/stripe-webhook-event'
+import { computeEnrollmentAccessWindow } from '@repo/bookings-payments'
+
+const HOOK_TIMEOUT = 300000
+const TEST_TIMEOUT = 60000
+const runId = Math.random().toString(36).slice(2, 10)
+const connectAccountId = `acct_course_enroll_${runId}`
+
+function request(body: string, signature = 't=123,v1=valid') {
+  return new NextRequest('http://localhost/api/stripe/webhook', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'stripe-signature': signature,
+    },
+    body,
+  })
+}
+
+describe('Course purchase enrollment (Stripe webhook)', () => {
+  let payload: Payload
+  let tenantId: number
+  let userId: number
+  let eventTypeId: number
+  let fixedCourseId: number
+  let durationCourseId: number
+  const fixedPurchaseTime = new Date(Date.UTC(2026, 6, 29, 12, 0, 0))
+
+  beforeAll(async () => {
+    const payloadConfig = await config
+    payload = await getPayload({ config: payloadConfig })
+
+    const tenant = await payload.create({
+      collection: 'tenants',
+      data: {
+        name: 'Course Purchase Enrollment Tenant',
+        slug: `course-purchase-enroll-${Date.now()}`,
+        stripeConnectAccountId: connectAccountId,
+        stripeConnectOnboardingStatus: 'active',
+        timeZone: 'Europe/Dublin',
+      },
+      overrideAccess: true,
+    })
+    tenantId = tenant.id as number
+
+    const user = await payload.create({
+      collection: 'users',
+      data: {
+        name: 'Course Purchase User',
+        email: `course-purchase-enroll-${Date.now()}@test.com`,
+        password: 'test',
+        role: ['user'],
+        emailVerified: true,
+      },
+      draft: false,
+      overrideAccess: true,
+    } as Parameters<typeof payload.create>[0])
+    userId = user.id as number
+
+    const eventType = await payload.create({
+      collection: 'event-types',
+      data: {
+        name: `Course Purchase Class ${Date.now()}`,
+        places: 10,
+        description: 'Test',
+        tenant: tenantId,
+      },
+      overrideAccess: true,
+    })
+    eventTypeId = eventType.id as number
+
+    const fixedCourse = await payload.create({
+      collection: 'courses' as import('payload').CollectionSlug,
+      data: {
+        title: 'Fixed Cohort Course',
+        slug: `fixed-course-${Date.now()}`,
+        startDate: '2026-09-01',
+        endDate: '2026-10-26',
+        allowedEventTypes: [eventTypeId],
+        status: 'open',
+        tenant: tenantId,
+        priceInformation: { price: 99 },
+      },
+      overrideAccess: true,
+      context: { skipStripeSync: true },
+    })
+    fixedCourseId = fixedCourse.id as number
+
+    const durationCourse = await payload.create({
+      collection: 'courses' as import('payload').CollectionSlug,
+      data: {
+        title: '8-Week Anytime Course',
+        slug: `duration-course-${Date.now()}`,
+        durationLength: 8,
+        durationUnit: 'weeks',
+        allowedEventTypes: [eventTypeId],
+        status: 'open',
+        tenant: tenantId,
+        priceInformation: { price: 120 },
+        maxEnrollments: 1,
+      },
+      overrideAccess: true,
+      context: { skipStripeSync: true },
+    })
+    durationCourseId = durationCourse.id as number
+  }, HOOK_TIMEOUT)
+
+  beforeEach(() => {
+    process.env.STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY || 'sk_test_placeholder'
+    process.env.STRIPE_CONNECT_CLIENT_ID =
+      process.env.STRIPE_CONNECT_CLIENT_ID || 'ca_test_placeholder'
+    process.env.STRIPE_CONNECT_WEBHOOK_SECRET =
+      process.env.STRIPE_CONNECT_WEBHOOK_SECRET || 'whsec_placeholder'
+    process.env.ENABLE_TEST_WEBHOOKS = 'true'
+    vi.mocked(webhookVerify.verifyStripeConnectWebhook).mockReset()
+    vi.mocked(webhookProcessed.hasProcessedStripeConnectEvent).mockReset()
+    vi.mocked(webhookProcessed.markStripeConnectEventProcessed).mockReset()
+    vi.mocked(webhookProcessed.hasProcessedStripeConnectEvent).mockReturnValue(false)
+  })
+
+  afterAll(async () => {
+    if (payload?.db) {
+      try {
+        await payload.delete({
+          collection: 'course-enrollments' as import('payload').CollectionSlug,
+          where: { tenant: { equals: tenantId } },
+          overrideAccess: true,
+        })
+        await payload.delete({
+          collection: 'courses' as import('payload').CollectionSlug,
+          where: { tenant: { equals: tenantId } },
+          overrideAccess: true,
+        })
+        await payload.delete({
+          collection: 'event-types',
+          where: { id: { equals: eventTypeId } },
+          overrideAccess: true,
+        })
+        await payload.delete({
+          collection: 'users',
+          where: { id: { equals: userId } },
+          overrideAccess: true,
+        })
+        await payload.delete({
+          collection: 'tenants',
+          where: { id: { equals: tenantId } },
+          overrideAccess: true,
+        })
+      } catch {
+        // ignore
+      }
+      await payload.db?.destroy?.()
+    }
+  })
+
+  it(
+    'payment_intent.succeeded creates enrollment with fixed access window from course dates',
+    async () => {
+      const event = createPaymentIntentSucceededEvent({
+        id: 'evt_course_fixed_1',
+        account: connectAccountId,
+        paymentIntentId: 'pi_course_fixed_1',
+        metadata: {
+          type: 'course_purchase',
+          userId: String(userId),
+          tenantId: String(tenantId),
+          courseId: String(fixedCourseId),
+        },
+      })
+      vi.mocked(webhookVerify.verifyStripeConnectWebhook).mockReturnValue(event as never)
+      const res = await POST(request(JSON.stringify(event)))
+      expect(res.status).toBe(200)
+
+      const enrollments = await payload.find({
+        collection: 'course-enrollments' as import('payload').CollectionSlug,
+        where: {
+          and: [
+            { user: { equals: userId } },
+            { course: { equals: fixedCourseId } },
+          ],
+        },
+        overrideAccess: true,
+      })
+      expect(enrollments.docs).toHaveLength(1)
+      const enrollment = enrollments.docs[0] as {
+        status?: string
+        accessStartsAt?: string
+        accessEndsAt?: string
+      }
+      expect(enrollment.status).toBe('active')
+      // Payload date-only fields may shift when persisted; stamp from the stored course.
+      const storedCourse = (await payload.findByID({
+        collection: 'courses' as import('payload').CollectionSlug,
+        id: fixedCourseId,
+        depth: 0,
+        overrideAccess: true,
+      })) as { startDate?: string | null; endDate?: string | null }
+      const expected = computeEnrollmentAccessWindow(
+        { startDate: storedCourse.startDate, endDate: storedCourse.endDate },
+        new Date(),
+      )
+      expect(enrollment.accessStartsAt).toBe(expected.accessStartsAt)
+      expect(enrollment.accessEndsAt).toBe(expected.accessEndsAt)
+    },
+    TEST_TIMEOUT,
+  )
+
+  it(
+    'payment_intent.succeeded stamps duration window from purchase time',
+    async () => {
+      vi.useFakeTimers({ now: fixedPurchaseTime, toFake: ['Date'] })
+      let res: Response
+      try {
+        const event = createPaymentIntentSucceededEvent({
+          id: 'evt_course_duration_1',
+          account: connectAccountId,
+          paymentIntentId: 'pi_course_duration_1',
+          metadata: {
+            type: 'course_purchase',
+            userId: String(userId),
+            tenantId: String(tenantId),
+            courseId: String(durationCourseId),
+          },
+        })
+        vi.mocked(webhookVerify.verifyStripeConnectWebhook).mockReturnValue(event as never)
+        res = await POST(request(JSON.stringify(event)))
+      } finally {
+        vi.useRealTimers()
+      }
+
+      expect(res.status).toBe(200)
+
+      const enrollments = await payload.find({
+        collection: 'course-enrollments' as import('payload').CollectionSlug,
+        where: {
+          and: [
+            { user: { equals: userId } },
+            { course: { equals: durationCourseId } },
+          ],
+        },
+        overrideAccess: true,
+      })
+      expect(enrollments.docs).toHaveLength(1)
+      const enrollment = enrollments.docs[0] as {
+        status?: string
+        accessStartsAt?: string
+        accessEndsAt?: string
+      }
+      expect(enrollment.status).toBe('active')
+      const expected = computeEnrollmentAccessWindow(
+        { durationLength: 8, durationUnit: 'weeks' },
+        fixedPurchaseTime,
+      )
+      expect(enrollment.accessStartsAt).toBe(expected.accessStartsAt)
+      expect(enrollment.accessEndsAt).toBe(expected.accessEndsAt)
+    },
+    TEST_TIMEOUT,
+  )
+
+  it(
+    'checkout.session.completed with no PaymentIntent still assigns the enrollment',
+    async () => {
+      // Use fixed course again with a distinct transaction id (idempotent by transactionId)
+      const event = createCheckoutSessionCompletedEvent({
+        id: 'evt_course_zero_1',
+        account: connectAccountId,
+        sessionId: 'cs_course_zero_1',
+        paymentIntent: null,
+        amountTotal: 0,
+        metadata: {
+          type: 'course_purchase',
+          userId: String(userId),
+          tenantId: String(tenantId),
+          courseId: String(fixedCourseId),
+        },
+      })
+      vi.mocked(webhookVerify.verifyStripeConnectWebhook).mockReturnValue(event as never)
+      const res = await POST(request(JSON.stringify(event)))
+      expect(res.status).toBe(200)
+
+      const enrollments = await payload.find({
+        collection: 'course-enrollments' as import('payload').CollectionSlug,
+        where: {
+          and: [
+            { user: { equals: userId } },
+            { course: { equals: fixedCourseId } },
+            { transactionId: { equals: 'cs_course_zero_1' } },
+          ],
+        },
+        overrideAccess: true,
+      })
+      expect(enrollments.docs).toHaveLength(1)
+      expect((enrollments.docs[0] as { status?: string }).status).toBe('active')
+    },
+    TEST_TIMEOUT,
+  )
+
+  it(
+    'rejects second purchase when course is sold out',
+    async () => {
+      // durationCourseId has maxEnrollments: 1 and already has an active enrollment from prior test
+      const otherUser = await payload.create({
+        collection: 'users',
+        data: {
+          name: 'Course Sold Out User',
+          email: `course-sold-out-${Date.now()}@test.com`,
+          password: 'test',
+          role: ['user'],
+          emailVerified: true,
+        },
+        draft: false,
+        overrideAccess: true,
+      } as Parameters<typeof payload.create>[0])
+
+      try {
+        const event = createPaymentIntentSucceededEvent({
+          id: 'evt_course_sold_out_1',
+          account: connectAccountId,
+          paymentIntentId: 'pi_course_sold_out_1',
+          metadata: {
+            type: 'course_purchase',
+            userId: String(otherUser.id),
+            tenantId: String(tenantId),
+            courseId: String(durationCourseId),
+          },
+        })
+        vi.mocked(webhookVerify.verifyStripeConnectWebhook).mockReturnValue(event as never)
+        const res = await POST(request(JSON.stringify(event)))
+        // Webhook still returns 200; enrollment is skipped (sold_out)
+        expect(res.status).toBe(200)
+
+        const enrollments = await payload.find({
+          collection: 'course-enrollments' as import('payload').CollectionSlug,
+          where: {
+            and: [
+              { user: { equals: otherUser.id } },
+              { course: { equals: durationCourseId } },
+            ],
+          },
+          overrideAccess: true,
+        })
+        expect(enrollments.docs).toHaveLength(0)
+      } finally {
+        await payload.delete({
+          collection: 'users',
+          where: { id: { equals: otherUser.id } },
+          overrideAccess: true,
+        })
+      }
+    },
+    TEST_TIMEOUT,
+  )
+})

--- a/apps/atnd-me/tests/int/post-booking-email.int.spec.ts
+++ b/apps/atnd-me/tests/int/post-booking-email.int.spec.ts
@@ -357,7 +357,7 @@ describe('Post-booking email integration', () => {
         expect.arrayContaining(["We'd love your review", 'Thanks for booking']),
       )
 
-      const deliveries = await payload.find({
+      let deliveries = await payload.find({
         collection: POST_BOOKING_EMAIL_DELIVERIES_SLUG,
         where: {
           and: [
@@ -370,7 +370,30 @@ describe('Post-booking email integration', () => {
         overrideAccess: true,
       })
 
+      for (
+        let attempt = 0;
+        attempt < 20 &&
+        (deliveries.totalDocs < 2 ||
+          deliveries.docs.filter((doc) => doc.status === 'sent').length < 2);
+        attempt += 1
+      ) {
+        await new Promise((resolve) => setTimeout(resolve, 50))
+        deliveries = await payload.find({
+          collection: POST_BOOKING_EMAIL_DELIVERIES_SLUG,
+          where: {
+            and: [
+              { tenant: { equals: tenantId } },
+              { user: { equals: userId } },
+              { timeslot: { equals: multiEmailTimeslot.id } },
+            ],
+          },
+          limit: 10,
+          overrideAccess: true,
+        })
+      }
+
       expect(deliveries.totalDocs).toBe(2)
+      expect(deliveries.docs.every((doc) => doc.status === 'sent')).toBe(true)
     },
     TEST_TIMEOUT,
   )

--- a/apps/atnd-me/tests/unit/assign-course-enrollment-from-purchase.test.ts
+++ b/apps/atnd-me/tests/unit/assign-course-enrollment-from-purchase.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from 'vitest'
+import { assignCourseEnrollmentFromPurchase } from '@/lib/stripe-connect/webhook/assign-course-enrollment-from-purchase'
+
+function mockPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    logger: { error: vi.fn() },
+    find: vi.fn().mockResolvedValue({ docs: [], totalDocs: 0 }),
+    findByID: vi.fn().mockResolvedValue({
+      status: 'open',
+      startDate: '2026-09-01',
+      endDate: '2026-10-26',
+    }),
+    create: vi.fn().mockResolvedValue({ id: 55 }),
+    ...overrides,
+  } as any
+}
+
+describe('assignCourseEnrollmentFromPurchase', () => {
+  it('skips non-course purchases', async () => {
+    const payload = mockPayload()
+    const result = await assignCourseEnrollmentFromPurchase({
+      payload,
+      tenantId: 1,
+      metadata: { type: 'class_pass_purchase' },
+      transactionId: 'pi_1',
+    })
+    expect(result).toEqual({ assigned: false, reason: 'not_course_purchase' })
+  })
+
+  it('is idempotent when enrollment already exists for transaction', async () => {
+    const payload = mockPayload({
+      find: vi.fn().mockResolvedValue({ docs: [{ id: 12 }], totalDocs: 1 }),
+    })
+    const result = await assignCourseEnrollmentFromPurchase({
+      payload,
+      tenantId: 1,
+      metadata: { type: 'course_purchase', userId: '3', courseId: '4' },
+      transactionId: 'pi_1',
+    })
+    expect(result).toEqual({ assigned: true, enrollmentId: 12 })
+    expect(payload.create).not.toHaveBeenCalled()
+  })
+
+  it('creates enrollment with stamped access window', async () => {
+    const payload = mockPayload()
+    const purchasedAt = new Date('2026-08-01T15:00:00.000Z')
+    const result = await assignCourseEnrollmentFromPurchase({
+      payload,
+      tenantId: 1,
+      metadata: { type: 'course_purchase', userId: '3', courseId: '4' },
+      transactionId: 'pi_1',
+      purchasedAt,
+    })
+    expect(result).toEqual({ assigned: true, enrollmentId: 55 })
+    expect(payload.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collection: 'course-enrollments',
+        data: expect.objectContaining({
+          user: 3,
+          course: 4,
+          tenant: 1,
+          status: 'active',
+          transactionId: 'pi_1',
+          accessStartsAt: '2026-09-01T00:00:00.000Z',
+          accessEndsAt: '2026-10-26T23:59:59.999Z',
+        }),
+      }),
+    )
+  })
+
+  it('rejects sold out courses', async () => {
+    const payload = mockPayload({
+      findByID: vi.fn().mockResolvedValue({
+        status: 'open',
+        startDate: '2026-09-01',
+        endDate: '2026-10-26',
+        maxEnrollments: 1,
+      }),
+      find: vi
+        .fn()
+        .mockResolvedValueOnce({ docs: [], totalDocs: 0 }) // idempotency lookup
+        .mockResolvedValueOnce({ docs: [], totalDocs: 1 }), // active count
+    })
+    const result = await assignCourseEnrollmentFromPurchase({
+      payload,
+      tenantId: 1,
+      metadata: { type: 'course_purchase', userId: '3', courseId: '4' },
+      transactionId: 'pi_1',
+    })
+    expect(result).toEqual({ assigned: false, reason: 'sold_out' })
+  })
+})

--- a/apps/atnd-me/tests/unit/build-course-enrollment-from-purchase.test.ts
+++ b/apps/atnd-me/tests/unit/build-course-enrollment-from-purchase.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { buildCourseEnrollmentFromPurchase } from '@repo/bookings-payments'
+
+describe('buildCourseEnrollmentFromPurchase (atnd-me)', () => {
+  it('stamps fixed-window enrollment fields for webhook create', () => {
+    const purchasedAt = new Date('2026-08-01T15:00:00.000Z')
+    expect(
+      buildCourseEnrollmentFromPurchase({
+        userId: 9,
+        courseId: 4,
+        tenantId: 2,
+        transactionId: 'pi_abc',
+        purchasedAt,
+        course: { startDate: '2026-09-01', endDate: '2026-10-26' },
+      }),
+    ).toMatchObject({
+      user: 9,
+      course: 4,
+      tenant: 2,
+      status: 'active',
+      transactionId: 'pi_abc',
+      accessStartsAt: '2026-09-01T00:00:00.000Z',
+      accessEndsAt: '2026-10-26T23:59:59.999Z',
+    })
+  })
+})

--- a/apps/atnd-me/tests/unit/course-email/cancel-transition.test.ts
+++ b/apps/atnd-me/tests/unit/course-email/cancel-transition.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { isCancelledEnrollmentTransition } from '@/lib/course-email/cancel-transition'
+
+describe('isCancelledEnrollmentTransition', () => {
+  it('returns true when status changes to cancelled', () => {
+    expect(
+      isCancelledEnrollmentTransition({
+        doc: { status: 'cancelled' },
+        previousDoc: { status: 'active' },
+        operation: 'update',
+      }),
+    ).toBe(true)
+  })
+
+  it('returns false when enrollment was already cancelled', () => {
+    expect(
+      isCancelledEnrollmentTransition({
+        doc: { status: 'cancelled' },
+        previousDoc: { status: 'cancelled' },
+        operation: 'update',
+      }),
+    ).toBe(false)
+  })
+
+  it('returns false for non-cancelled updates', () => {
+    expect(
+      isCancelledEnrollmentTransition({
+        doc: { status: 'completed' },
+        previousDoc: { status: 'active' },
+        operation: 'update',
+      }),
+    ).toBe(false)
+  })
+})

--- a/apps/atnd-me/tests/unit/course-email/resolve-send-time.test.ts
+++ b/apps/atnd-me/tests/unit/course-email/resolve-send-time.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest'
+import {
+  COURSE_EMAIL_SEND_TIMINGS,
+  resolveCourseEmailSendAt,
+} from '@/lib/course-email/resolve-send-time'
+
+describe('COURSE_EMAIL_SEND_TIMINGS', () => {
+  it('includes purchase and calendar-relative timings', () => {
+    expect(COURSE_EMAIL_SEND_TIMINGS).toEqual(
+      expect.arrayContaining([
+        'after_purchase',
+        'one_week_before_start',
+        'one_day_before_start',
+        'one_day_after_start',
+        'one_day_before_end',
+        'one_day_after_end',
+      ]),
+    )
+  })
+})
+
+describe('resolveCourseEmailSendAt', () => {
+  const accessStartsAt = '2026-09-08T00:00:00.000Z'
+  const accessEndsAt = '2026-11-03T23:59:59.999Z'
+  const timeZone = 'Europe/Dublin'
+
+  it('returns immediate for after_purchase', () => {
+    expect(
+      resolveCourseEmailSendAt({
+        sendTiming: 'after_purchase',
+        accessStartsAt,
+        accessEndsAt,
+        timeZone,
+        now: new Date('2026-08-01T12:00:00.000Z'),
+      }),
+    ).toEqual({ kind: 'immediate' })
+  })
+
+  it('schedules one week before start at 9am local', () => {
+    // 2026-09-08 is a Tuesday in Dublin; one week before = 2026-09-01 09:00 IST (UTC+1) = 08:00Z
+    const result = resolveCourseEmailSendAt({
+      sendTiming: 'one_week_before_start',
+      accessStartsAt,
+      accessEndsAt,
+      timeZone,
+      now: new Date('2026-08-01T12:00:00.000Z'),
+    })
+    expect(result).toEqual({
+      kind: 'scheduled',
+      sendAt: new Date('2026-09-01T08:00:00.000Z'),
+    })
+  })
+
+  it('schedules one day before start at 9am local', () => {
+    const result = resolveCourseEmailSendAt({
+      sendTiming: 'one_day_before_start',
+      accessStartsAt,
+      accessEndsAt,
+      timeZone,
+      now: new Date('2026-08-01T12:00:00.000Z'),
+    })
+    expect(result).toEqual({
+      kind: 'scheduled',
+      sendAt: new Date('2026-09-07T08:00:00.000Z'),
+    })
+  })
+
+  it('schedules one day after start at 9am local', () => {
+    const result = resolveCourseEmailSendAt({
+      sendTiming: 'one_day_after_start',
+      accessStartsAt,
+      accessEndsAt,
+      timeZone,
+      now: new Date('2026-08-01T12:00:00.000Z'),
+    })
+    expect(result).toEqual({
+      kind: 'scheduled',
+      sendAt: new Date('2026-09-09T08:00:00.000Z'),
+    })
+  })
+
+  it('schedules one day before end at 9am local', () => {
+    // accessEndsAt 2026-11-03 → one day before = 2026-11-02 09:00 IST = 09:00Z (GMT in Nov)
+    const result = resolveCourseEmailSendAt({
+      sendTiming: 'one_day_before_end',
+      accessStartsAt,
+      accessEndsAt,
+      timeZone,
+      now: new Date('2026-08-01T12:00:00.000Z'),
+    })
+    expect(result).toEqual({
+      kind: 'scheduled',
+      sendAt: new Date('2026-11-02T09:00:00.000Z'),
+    })
+  })
+
+  it('schedules one day after end at 9am local', () => {
+    const result = resolveCourseEmailSendAt({
+      sendTiming: 'one_day_after_end',
+      accessStartsAt,
+      accessEndsAt,
+      timeZone,
+      now: new Date('2026-08-01T12:00:00.000Z'),
+    })
+    expect(result).toEqual({
+      kind: 'scheduled',
+      sendAt: new Date('2026-11-04T09:00:00.000Z'),
+    })
+  })
+
+  it('skips scheduled timings whose send time is already past', () => {
+    expect(
+      resolveCourseEmailSendAt({
+        sendTiming: 'one_day_before_start',
+        accessStartsAt,
+        accessEndsAt,
+        timeZone,
+        now: new Date('2026-09-07T10:00:00.000Z'),
+      }),
+    ).toEqual({ kind: 'skip', reason: 'send_time_past' })
+  })
+})

--- a/apps/atnd-me/tests/unit/course-email/types.test.ts
+++ b/apps/atnd-me/tests/unit/course-email/types.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import {
+  resolveActiveCourseEmailConfigs,
+  resolveCourseEmailConfigById,
+} from '@/lib/course-email/types'
+
+describe('resolveActiveCourseEmailConfigs', () => {
+  it('keeps only configs with id, subject, replyTo, and sendTiming', () => {
+    const configs = resolveActiveCourseEmailConfigs({
+      courseEmails: [
+        {
+          id: 'a',
+          subject: 'Welcome',
+          replyTo: 'hi@example.com',
+          sendTiming: 'after_purchase',
+          message: { root: {} },
+        },
+        { id: 'b', subject: 'Missing reply', sendTiming: 'after_purchase' },
+        {
+          id: 'c',
+          subject: 'Before start',
+          replyTo: 'hi@example.com',
+          sendTiming: 'one_day_before_start',
+        },
+      ],
+    })
+    expect(configs.map((c) => c.id)).toEqual(['a', 'c'])
+  })
+
+  it('returns empty for missing array', () => {
+    expect(resolveActiveCourseEmailConfigs({})).toEqual([])
+  })
+})
+
+describe('resolveCourseEmailConfigById', () => {
+  it('finds by id', () => {
+    const config = resolveCourseEmailConfigById(
+      {
+        courseEmails: [
+          {
+            id: 'x',
+            subject: 'Hi',
+            replyTo: 'a@b.com',
+            sendTiming: 'after_purchase',
+          },
+        ],
+      },
+      'x',
+    )
+    expect(config?.subject).toBe('Hi')
+  })
+})

--- a/apps/atnd-me/tests/unit/course-guest-checkout-route.test.ts
+++ b/apps/atnd-me/tests/unit/course-guest-checkout-route.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Guest course checkout: ensureGuestUser + PaymentIntent for course enrollment.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const {
+  mockEnsureGuestUser,
+  mockCreateTenantPaymentIntent,
+  mockEnsureStripeCustomerIdForAccount,
+  mockPayload,
+  mockResolveTenantSlugOrId,
+  mockResolveTenantForConnect,
+  mockCheckRateLimit,
+} = vi.hoisted(() => ({
+  mockEnsureGuestUser: vi.fn(),
+  mockCreateTenantPaymentIntent: vi.fn(),
+  mockEnsureStripeCustomerIdForAccount: vi.fn(),
+  mockResolveTenantSlugOrId: vi.fn(),
+  mockResolveTenantForConnect: vi.fn(),
+  mockCheckRateLimit: vi.fn().mockReturnValue({ allowed: true, retryAfterMs: 0 }),
+  mockPayload: {
+    findByID: vi.fn(),
+    find: vi.fn().mockResolvedValue({ docs: [], totalDocs: 0 }),
+  },
+}))
+
+vi.mock('@/lib/booking/ensureGuestUser', () => ({
+  ensureGuestUser: mockEnsureGuestUser,
+}))
+
+vi.mock('@/lib/payload', () => ({
+  getPayload: vi.fn().mockResolvedValue(mockPayload),
+}))
+
+vi.mock('@/lib/stripe-connect/api-helpers', () => ({
+  resolveTenantSlugOrId: mockResolveTenantSlugOrId,
+  resolveTenantForConnect: mockResolveTenantForConnect,
+}))
+
+const mockIsStripeTestAccount = vi.hoisted(() => vi.fn().mockReturnValue(true))
+
+vi.mock('@/lib/stripe-connect/test-accounts', () => ({
+  isStripeTestAccount: mockIsStripeTestAccount,
+}))
+
+vi.mock('@/lib/stripe-connect/charges', () => ({
+  createTenantPaymentIntent: mockCreateTenantPaymentIntent,
+}))
+
+vi.mock('@repo/bookings-payments', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@repo/bookings-payments')>()
+  return {
+    ...actual,
+    ensureStripeCustomerIdForAccount: mockEnsureStripeCustomerIdForAccount,
+  }
+})
+
+vi.mock('@/lib/onboarding/rateLimit', () => ({
+  checkRateLimit: mockCheckRateLimit,
+}))
+
+import { POST } from '@/app/api/courses/guest-checkout/route'
+
+function makeRequest(body: unknown) {
+  return new Request('http://localhost/api/courses/guest-checkout', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'x-forwarded-for': '1.2.3.4' },
+    body: JSON.stringify(body),
+  }) as any
+}
+
+describe('POST /api/courses/guest-checkout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsStripeTestAccount.mockReturnValue(true)
+    mockCheckRateLimit.mockReturnValue({ allowed: true, retryAfterMs: 0 })
+    mockResolveTenantSlugOrId.mockReturnValue('acme')
+    mockResolveTenantForConnect.mockResolvedValue({
+      id: 1,
+      stripeConnectAccountId: 'acct_placeholder_test',
+      stripeConnectOnboardingStatus: 'active',
+    })
+    mockPayload.findByID.mockResolvedValue({
+      id: 4,
+      status: 'open',
+      tenant: 1,
+      priceInformation: { price: 80 },
+    })
+    mockPayload.find.mockResolvedValue({ docs: [], totalDocs: 0 })
+    mockEnsureGuestUser.mockResolvedValue({
+      userId: 77,
+      created: true,
+      email: 'guest@example.com',
+      name: 'Sam Guest',
+    })
+    mockEnsureStripeCustomerIdForAccount.mockResolvedValue({ stripeCustomerId: 'cus_guest' })
+    mockCreateTenantPaymentIntent.mockResolvedValue({ client_secret: 'pi_live_secret' })
+  })
+
+  it('rejects incomplete guest email', async () => {
+    const res = await POST(
+      makeRequest({ courseId: 4, guestName: 'Sam', guestEmail: 'sam@ex' }),
+    )
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toMatchObject({
+      error: expect.stringMatching(/valid email/i),
+    })
+    expect(mockEnsureGuestUser).not.toHaveBeenCalled()
+  })
+
+  it('rejects short guest name', async () => {
+    const res = await POST(
+      makeRequest({ courseId: 4, guestName: 'S', guestEmail: 'sam@example.com' }),
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it('returns clientSecret for guest on test account', async () => {
+    const res = await POST(
+      makeRequest({ courseId: 4, guestName: 'Sam Guest', guestEmail: 'sam@example.com' }),
+    )
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.clientSecret).toMatch(/_secret_test$/)
+    expect(mockEnsureGuestUser).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: 'sam@example.com',
+        name: 'Sam Guest',
+        tenantId: 1,
+      }),
+    )
+  })
+
+  it('accepts guest fields via CheckoutForm metadata', async () => {
+    const res = await POST(
+      makeRequest({
+        price: 80,
+        metadata: {
+          courseId: '4',
+          guestName: 'Sam Guest',
+          guestEmail: 'sam@example.com',
+        },
+      }),
+    )
+    expect(res.status).toBe(200)
+  })
+
+  it('rate limits by email', async () => {
+    mockCheckRateLimit.mockImplementation(({ key }: { key: string }) => {
+      if (key.includes('email:')) return { allowed: false, retryAfterMs: 1000 }
+      return { allowed: true, retryAfterMs: 0 }
+    })
+    const res = await POST(
+      makeRequest({ courseId: 4, guestName: 'Sam Guest', guestEmail: 'sam@example.com' }),
+    )
+    expect(res.status).toBe(429)
+  })
+
+  it('creates PaymentIntent with productType course (not class-pass)', async () => {
+    mockIsStripeTestAccount.mockReturnValue(false)
+    mockResolveTenantForConnect.mockResolvedValue({
+      id: 1,
+      stripeConnectAccountId: 'acct_1RealConnectAccount',
+      stripeConnectOnboardingStatus: 'active',
+    })
+
+    const res = await POST(
+      makeRequest({ courseId: 4, guestName: 'Sam Guest', guestEmail: 'sam@example.com' }),
+    )
+    expect(res.status).toBe(200)
+    expect(mockCreateTenantPaymentIntent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        productType: 'course',
+        metadata: expect.objectContaining({
+          type: 'course_purchase',
+          guestCheckout: 'true',
+          courseId: '4',
+        }),
+      }),
+    )
+  })
+})

--- a/apps/atnd-me/tests/unit/course-purchase-route.test.ts
+++ b/apps/atnd-me/tests/unit/course-purchase-route.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Auth course purchase: create PaymentIntent for course enrollment.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const {
+  mockCreateTenantPaymentIntent,
+  mockEnsureStripeCustomerIdForAccount,
+  mockPayload,
+  mockGetCurrentUser,
+  mockResolveTenantSlugOrId,
+  mockResolveTenantForConnect,
+} = vi.hoisted(() => ({
+  mockCreateTenantPaymentIntent: vi.fn(),
+  mockEnsureStripeCustomerIdForAccount: vi.fn(),
+  mockGetCurrentUser: vi.fn(),
+  mockResolveTenantSlugOrId: vi.fn(),
+  mockResolveTenantForConnect: vi.fn(),
+  mockPayload: {
+    findByID: vi.fn(),
+    find: vi.fn().mockResolvedValue({ docs: [], totalDocs: 0 }),
+  },
+}))
+
+vi.mock('@/lib/payload', () => ({
+  getPayload: vi.fn().mockResolvedValue(mockPayload),
+}))
+
+vi.mock('@/lib/stripe-connect/api-helpers', () => ({
+  getCurrentUser: mockGetCurrentUser,
+  resolveTenantSlugOrId: mockResolveTenantSlugOrId,
+  resolveTenantForConnect: mockResolveTenantForConnect,
+}))
+
+const mockIsStripeTestAccount = vi.hoisted(() => vi.fn().mockReturnValue(true))
+
+vi.mock('@/lib/stripe-connect/test-accounts', () => ({
+  isStripeTestAccount: mockIsStripeTestAccount,
+}))
+
+vi.mock('@/lib/stripe-connect/charges', () => ({
+  createTenantPaymentIntent: mockCreateTenantPaymentIntent,
+}))
+
+vi.mock('@repo/bookings-payments', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@repo/bookings-payments')>()
+  return {
+    ...actual,
+    ensureStripeCustomerIdForAccount: mockEnsureStripeCustomerIdForAccount,
+  }
+})
+
+import { POST } from '@/app/api/courses/purchase/route'
+
+function makeRequest(body: unknown) {
+  return new Request('http://localhost/api/courses/purchase', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  }) as any
+}
+
+describe('POST /api/courses/purchase', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsStripeTestAccount.mockReturnValue(true)
+    mockGetCurrentUser.mockResolvedValue({ id: 7, email: 'a@b.com', name: 'Ada' })
+    mockResolveTenantSlugOrId.mockReturnValue('acme')
+    mockResolveTenantForConnect.mockResolvedValue({
+      id: 1,
+      stripeConnectAccountId: 'acct_placeholder_test',
+      stripeConnectOnboardingStatus: 'active',
+    })
+    mockPayload.findByID.mockResolvedValue({
+      id: 4,
+      status: 'open',
+      tenant: 1,
+      priceInformation: { price: 99 },
+      maxEnrollments: null,
+    })
+    mockPayload.find.mockResolvedValue({ docs: [], totalDocs: 0 })
+    mockEnsureStripeCustomerIdForAccount.mockResolvedValue({ stripeCustomerId: 'cus_test' })
+    mockCreateTenantPaymentIntent.mockResolvedValue({ client_secret: 'pi_live_secret' })
+  })
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetCurrentUser.mockResolvedValue(null)
+    const res = await POST(makeRequest({ courseId: 4 }))
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 400 when courseId missing', async () => {
+    const res = await POST(makeRequest({}))
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toMatchObject({ error: expect.stringMatching(/courseId/i) })
+  })
+
+  it('returns clientSecret for open course on test account', async () => {
+    const res = await POST(makeRequest({ courseId: 4 }))
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.clientSecret).toMatch(/_secret_test$/)
+    expect(json.stripeAccountId).toBe('acct_placeholder_test')
+  })
+
+  it('accepts courseId via CheckoutForm metadata', async () => {
+    const res = await POST(makeRequest({ price: 99, metadata: { courseId: '4' } }))
+    expect(res.status).toBe(200)
+  })
+
+  it('returns 400 when course sold out', async () => {
+    mockPayload.findByID.mockResolvedValue({
+      id: 4,
+      status: 'open',
+      tenant: 1,
+      priceInformation: { price: 99 },
+      maxEnrollments: 1,
+    })
+    mockPayload.find.mockResolvedValue({ docs: [], totalDocs: 1 })
+    const res = await POST(makeRequest({ courseId: 4 }))
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toMatchObject({ error: expect.stringMatching(/sold out/i) })
+  })
+
+  it('creates PaymentIntent with productType course (not class-pass)', async () => {
+    mockIsStripeTestAccount.mockReturnValue(false)
+    mockResolveTenantForConnect.mockResolvedValue({
+      id: 1,
+      stripeConnectAccountId: 'acct_1RealConnectAccount',
+      stripeConnectOnboardingStatus: 'active',
+    })
+
+    const res = await POST(makeRequest({ courseId: 4 }))
+    expect(res.status).toBe(200)
+    expect(mockCreateTenantPaymentIntent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        productType: 'course',
+        classPriceAmount: 9900,
+        metadata: expect.objectContaining({ type: 'course_purchase', courseId: '4' }),
+      }),
+    )
+  })
+})

--- a/apps/atnd-me/tests/unit/create-checkout-session-class-pass-fee.test.ts
+++ b/apps/atnd-me/tests/unit/create-checkout-session-class-pass-fee.test.ts
@@ -148,6 +148,27 @@ describe('create-checkout-session route – class pass fee regression', () => {
     )
   })
 
+  it('computes fee with productType course for course_purchase', async () => {
+    mockCalculateBookingFeeAmount.mockResolvedValue(120)
+
+    const res = await POST(
+      request({
+        priceId: 'price_course_abc',
+        quantity: 1,
+        mode: 'payment',
+        metadata: { type: 'course_purchase', tenantId: String(ACTIVE_TENANT.id) },
+      }),
+    )
+
+    expect(res.status).toBe(200)
+    expect(mockCalculateBookingFeeAmount).toHaveBeenCalledWith(
+      expect.objectContaining({ productType: 'course', classPriceAmount: 3000 }),
+    )
+    expect(mockCreateTenantCheckoutSession).toHaveBeenCalledWith(
+      expect.objectContaining({ bookingFeeAmount: 120, productType: 'course' }),
+    )
+  })
+
   it('does not compute fee and passes productType undefined for payment mode without class_pass_purchase', async () => {
     await POST(
       request({

--- a/apps/atnd-me/tests/unit/event-places-availability.test.ts
+++ b/apps/atnd-me/tests/unit/event-places-availability.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  eventPlacesAvailability,
+  eventPlacesLabel,
+} from '@/components/events/eventPlacesAvailability'
+
+describe('eventPlacesAvailability', () => {
+  it('hard sold-out only when confirmed bookings fill the event', () => {
+    expect(
+      eventPlacesAvailability({
+        remainingCapacity: 0,
+        remainingConfirmedOnly: 0,
+        ownHoldQuantity: 0,
+      }),
+    ).toEqual({
+      soldOut: true,
+      temporarilyUnavailable: false,
+      viewerRemaining: 0,
+    })
+  })
+
+  it('treats hold-only exhaustion as temporary, not sold out', () => {
+    expect(
+      eventPlacesAvailability({
+        remainingCapacity: 0,
+        remainingConfirmedOnly: 2,
+        ownHoldQuantity: 0,
+      }),
+    ).toEqual({
+      soldOut: false,
+      temporarilyUnavailable: true,
+      viewerRemaining: 0,
+    })
+  })
+
+  it('keeps checkout available when global remaining is 0 but viewer has a hold', () => {
+    expect(
+      eventPlacesAvailability({
+        remainingCapacity: 0,
+        remainingConfirmedOnly: 3,
+        ownHoldQuantity: 1,
+      }),
+    ).toEqual({
+      soldOut: false,
+      temporarilyUnavailable: false,
+      viewerRemaining: 1,
+    })
+  })
+
+  it('does not inflate places after a client-side hold on stale SSR remaining', () => {
+    // SSR still shows 3; viewer just reserved 1 on this page — label stays at SSR global.
+    expect(
+      eventPlacesAvailability({
+        remainingCapacity: 3,
+        remainingConfirmedOnly: 3,
+        ownHoldQuantity: 1,
+      }),
+    ).toEqual({
+      soldOut: false,
+      temporarilyUnavailable: false,
+      viewerRemaining: 3,
+    })
+  })
+})
+
+describe('eventPlacesLabel', () => {
+  it('formats remaining places', () => {
+    expect(eventPlacesLabel(0)).toBe('Sold out')
+    expect(eventPlacesLabel(1)).toBe('1 place left')
+    expect(eventPlacesLabel(3)).toBe('3 places left')
+  })
+})

--- a/apps/atnd-me/tests/unit/event-places-availability.test.ts
+++ b/apps/atnd-me/tests/unit/event-places-availability.test.ts
@@ -48,11 +48,11 @@ describe('eventPlacesAvailability', () => {
     })
   })
 
-  it('does not inflate places after a client-side hold on stale SSR remaining', () => {
-    // SSR still shows 3; viewer just reserved 1 on this page — label stays at SSR global.
+  it('adds the viewer own hold back when global remaining already subtracts it', () => {
+    // places=3, viewer hold=1 → global remaining=2; viewer should still see 3.
     expect(
       eventPlacesAvailability({
-        remainingCapacity: 3,
+        remainingCapacity: 2,
         remainingConfirmedOnly: 3,
         ownHoldQuantity: 1,
       }),
@@ -60,6 +60,20 @@ describe('eventPlacesAvailability', () => {
       soldOut: false,
       temporarilyUnavailable: false,
       viewerRemaining: 3,
+    })
+  })
+
+  it('caps viewer remaining at confirmed-only capacity', () => {
+    expect(
+      eventPlacesAvailability({
+        remainingCapacity: 2,
+        remainingConfirmedOnly: 2,
+        ownHoldQuantity: 1,
+      }),
+    ).toEqual({
+      soldOut: false,
+      temporarilyUnavailable: false,
+      viewerRemaining: 2,
     })
   })
 })

--- a/apps/atnd-me/tests/unit/format-course-access-window.test.ts
+++ b/apps/atnd-me/tests/unit/format-course-access-window.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { formatCourseAccessWindowCopy } from '@/lib/courses/format-course-access-window'
+
+describe('formatCourseAccessWindowCopy', () => {
+  it('formats fixed dates', () => {
+    expect(
+      formatCourseAccessWindowCopy({
+        startDate: '2026-09-01',
+        endDate: '2026-10-26',
+      }),
+    ).toBe('1 Sep 2026 – 26 Oct 2026')
+  })
+
+  it('formats duration weeks from purchase', () => {
+    expect(
+      formatCourseAccessWindowCopy({
+        durationLength: 8,
+        durationUnit: 'weeks',
+      }),
+    ).toBe('8 weeks from purchase')
+  })
+
+  it('formats singular day duration', () => {
+    expect(
+      formatCourseAccessWindowCopy({
+        durationLength: 1,
+        durationUnit: 'days',
+      }),
+    ).toBe('1 day from purchase')
+  })
+
+  it('returns null when incomplete', () => {
+    expect(formatCourseAccessWindowCopy({})).toBeNull()
+  })
+})

--- a/apps/atnd-me/tests/unit/guest-reserve-hold-route.test.ts
+++ b/apps/atnd-me/tests/unit/guest-reserve-hold-route.test.ts
@@ -7,11 +7,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 const {
   mockEnsureGuestUser,
   mockUpsertCheckoutHold,
+  mockComputeCapacityBreakdownWithHolds,
   mockPayload,
   mockCheckRateLimit,
 } = vi.hoisted(() => ({
   mockEnsureGuestUser: vi.fn(),
   mockUpsertCheckoutHold: vi.fn(),
+  mockComputeCapacityBreakdownWithHolds: vi.fn(),
   mockCheckRateLimit: vi.fn().mockReturnValue({ allowed: true, retryAfterMs: 0 }),
   mockPayload: {
     findByID: vi.fn(),
@@ -27,6 +29,7 @@ vi.mock('@repo/bookings-payments', async (importOriginal) => {
   return {
     ...actual,
     upsertCheckoutHold: mockUpsertCheckoutHold,
+    computeCapacityBreakdownWithHolds: mockComputeCapacityBreakdownWithHolds,
   }
 })
 
@@ -66,6 +69,13 @@ describe('POST /api/events/guest-reserve-hold', () => {
       name: 'Sam Guest',
     })
     mockUpsertCheckoutHold.mockResolvedValue({ holdId: 55, quantity: 2 })
+    mockComputeCapacityBreakdownWithHolds.mockResolvedValue({
+      places: 3,
+      confirmed: 0,
+      held: 2,
+      remaining: 1,
+      remainingConfirmedOnly: 3,
+    })
     mockPayload.findByID.mockResolvedValue({
       id: TIMESLOT_ID,
       active: true,
@@ -85,7 +95,12 @@ describe('POST /api/events/guest-reserve-hold', () => {
     const body = await res.json()
 
     expect(res.status).toBe(200)
-    expect(body).toEqual({ holdId: 55, quantity: 2 })
+    expect(body).toEqual({
+      holdId: 55,
+      quantity: 2,
+      remainingCapacity: 1,
+      remainingConfirmedOnly: 3,
+    })
     expect(mockEnsureGuestUser).toHaveBeenCalledWith(
       expect.objectContaining({
         email: 'sam.guest@example.com',

--- a/apps/atnd-me/tests/unit/resolve-course-for-purchase.test.ts
+++ b/apps/atnd-me/tests/unit/resolve-course-for-purchase.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isCompleteGuestEmail,
+  resolveCourseForPurchase,
+} from '@/lib/courses/resolve-course-for-purchase'
+
+const openCourse = {
+  id: 4,
+  status: 'open',
+  tenant: 1,
+  priceInformation: { price: 120 },
+  maxEnrollments: 10,
+}
+
+describe('resolveCourseForPurchase', () => {
+  it('accepts an open priced course under capacity', () => {
+    expect(
+      resolveCourseForPurchase({
+        course: openCourse,
+        expectedTenantId: 1,
+        activeEnrollmentCount: 2,
+      }),
+    ).toEqual({
+      ok: true,
+      course: openCourse,
+      priceCents: 12000,
+      tenantId: 1,
+    })
+  })
+
+  it('rejects missing course', () => {
+    expect(
+      resolveCourseForPurchase({
+        course: null,
+        expectedTenantId: 1,
+        activeEnrollmentCount: 0,
+      }),
+    ).toEqual({ ok: false, status: 404, error: 'Course not found' })
+  })
+
+  it('rejects wrong tenant', () => {
+    expect(
+      resolveCourseForPurchase({
+        course: openCourse,
+        expectedTenantId: 99,
+        activeEnrollmentCount: 0,
+      }),
+    ).toEqual({ ok: false, status: 404, error: 'Course not found' })
+  })
+
+  it('rejects non-open status', () => {
+    expect(
+      resolveCourseForPurchase({
+        course: { ...openCourse, status: 'closed' },
+        expectedTenantId: 1,
+        activeEnrollmentCount: 0,
+      }),
+    ).toMatchObject({ ok: false, status: 400, error: expect.stringMatching(/not open/i) })
+  })
+
+  it('rejects missing price', () => {
+    expect(
+      resolveCourseForPurchase({
+        course: { ...openCourse, priceInformation: { price: 0 } },
+        expectedTenantId: 1,
+        activeEnrollmentCount: 0,
+      }),
+    ).toMatchObject({ ok: false, status: 400, error: expect.stringMatching(/no price/i) })
+  })
+
+  it('rejects sold out', () => {
+    expect(
+      resolveCourseForPurchase({
+        course: openCourse,
+        expectedTenantId: 1,
+        activeEnrollmentCount: 10,
+      }),
+    ).toMatchObject({ ok: false, status: 400, error: expect.stringMatching(/sold out/i) })
+  })
+})
+
+describe('isCompleteGuestEmail', () => {
+  it('accepts complete emails only', () => {
+    expect(isCompleteGuestEmail('sam@example.com')).toBe(true)
+    expect(isCompleteGuestEmail('sam@ex')).toBe(false)
+    expect(isCompleteGuestEmail('sam@')).toBe(false)
+  })
+})

--- a/apps/atnd-me/tests/unit/stripe-connect/booking-fee.test.ts
+++ b/apps/atnd-me/tests/unit/stripe-connect/booking-fee.test.ts
@@ -64,13 +64,21 @@ describe('Booking fee (step 2.7.1)', () => {
       expect(pct).toBe(2)
     })
 
-    it('returns default 3% for class-pass and 4% for subscription', async () => {
+    it('returns default 3% for class-pass, 3% for course, and 4% for subscription', async () => {
       vi.mocked(mockPayload.findGlobal).mockResolvedValue({
-        defaults: { dropInPercent: 2, classPassPercent: 3, subscriptionPercent: 4 },
+        defaults: {
+          dropInPercent: 2,
+          classPassPercent: 3,
+          coursePercent: 3,
+          subscriptionPercent: 4,
+        },
         overrides: [],
       })
       expect(
         await getEffectiveBookingFeePercent({ tenantId, productType: 'class-pass', payload: mockPayload }),
+      ).toBe(3)
+      expect(
+        await getEffectiveBookingFeePercent({ tenantId, productType: 'course', payload: mockPayload }),
       ).toBe(3)
       expect(
         await getEffectiveBookingFeePercent({ tenantId, productType: 'subscription', payload: mockPayload }),
@@ -83,9 +91,36 @@ describe('Booking fee (step 2.7.1)', () => {
       expect(await getEffectiveBookingFeePercent({ tenantId, productType: 'class-pass', payload: mockPayload })).toBe(
         3,
       )
+      expect(await getEffectiveBookingFeePercent({ tenantId, productType: 'course', payload: mockPayload })).toBe(3)
       expect(await getEffectiveBookingFeePercent({ tenantId, productType: 'subscription', payload: mockPayload })).toBe(
         4,
       )
+    })
+
+    it('applies per-tenant course override when present', async () => {
+      vi.mocked(mockPayload.findGlobal).mockResolvedValue({
+        defaults: {
+          dropInPercent: 2,
+          classPassPercent: 3,
+          coursePercent: 3,
+          subscriptionPercent: 4,
+        },
+        overrides: [
+          {
+            tenant: tenantId,
+            dropInPercent: null,
+            classPassPercent: null,
+            coursePercent: 7,
+            subscriptionPercent: null,
+          },
+        ],
+      })
+      expect(
+        await getEffectiveBookingFeePercent({ tenantId, productType: 'course', payload: mockPayload }),
+      ).toBe(7)
+      expect(
+        await getEffectiveBookingFeePercent({ tenantId, productType: 'class-pass', payload: mockPayload }),
+      ).toBe(3)
     })
 
     it('applies per-tenant override when present (override > default)', async () => {

--- a/packages/bookings-payments/__tests__/build-course-enrollment-from-purchase.test.ts
+++ b/packages/bookings-payments/__tests__/build-course-enrollment-from-purchase.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Purchase helper: stamp access window onto enrollment create payload.
+ */
+import { describe, it, expect } from "vitest";
+import { buildCourseEnrollmentFromPurchase } from "../src/course/utilities/build-course-enrollment-from-purchase";
+
+describe("buildCourseEnrollmentFromPurchase", () => {
+  it("builds enrollment data for a fixed-date course", () => {
+    const purchasedAt = new Date("2026-08-01T15:00:00.000Z");
+    expect(
+      buildCourseEnrollmentFromPurchase({
+        userId: 7,
+        courseId: 3,
+        tenantId: 1,
+        transactionId: "pi_test_123",
+        purchasedAt,
+        course: { startDate: "2026-09-01", endDate: "2026-10-26" },
+      }),
+    ).toEqual({
+      user: 7,
+      course: 3,
+      tenant: 1,
+      status: "active",
+      purchasedAt: purchasedAt.toISOString(),
+      accessStartsAt: "2026-09-01T00:00:00.000Z",
+      accessEndsAt: "2026-10-26T23:59:59.999Z",
+      transactionId: "pi_test_123",
+    });
+  });
+
+  it("builds enrollment data for a duration course from purchase", () => {
+    const purchasedAt = new Date("2026-07-29T12:00:00.000Z");
+    const result = buildCourseEnrollmentFromPurchase({
+      userId: 7,
+      courseId: 3,
+      tenantId: 1,
+      purchasedAt,
+      course: { durationLength: 8, durationUnit: "weeks" },
+    });
+    expect(result.accessStartsAt).toBe(purchasedAt.toISOString());
+    const expectedEnd = new Date(purchasedAt);
+    expectedEnd.setUTCDate(expectedEnd.getUTCDate() + 56);
+    expect(result.accessEndsAt).toBe(expectedEnd.toISOString());
+    expect(result.status).toBe("active");
+    expect(result.transactionId).toBeUndefined();
+  });
+});

--- a/packages/bookings-payments/__tests__/checkout-hold-service.test.ts
+++ b/packages/bookings-payments/__tests__/checkout-hold-service.test.ts
@@ -9,6 +9,7 @@ import {
   extendCheckoutHold,
   countActiveHoldQuantityForTimeslot,
   computeRemainingCapacityWithHolds,
+  computeCapacityBreakdownWithHolds,
   isHoldActive,
 } from '../src/checkout-holds/service'
 import { HOLD_TTL_MS, HOLD_MAX_LIFETIME_MS } from '../src/checkout-holds/constants'
@@ -545,6 +546,29 @@ describe('checkout hold service', () => {
 
       const remaining = await computeRemainingCapacityWithHolds(payload as never, TIMESLOT_ID)
       expect(remaining).toBe(0)
+    })
+
+    it('exposes confirmed-only remaining separately from hold-adjusted remaining', async () => {
+      confirmedCount = 1
+      holds.push({
+        id: 1,
+        user: OTHER_USER_ID,
+        timeslot: TIMESLOT_ID,
+        tenant: TENANT_ID,
+        quantity: 2,
+        expiresAt: iso(now + HOLD_TTL_MS),
+        status: 'active',
+      })
+      const payload = makePayload()
+
+      const breakdown = await computeCapacityBreakdownWithHolds(payload as never, TIMESLOT_ID)
+      expect(breakdown).toEqual({
+        places: PLACES,
+        confirmed: 1,
+        held: 2,
+        remaining: PLACES - 1 - 2,
+        remainingConfirmedOnly: PLACES - 1,
+      })
     })
   })
 })

--- a/packages/bookings-payments/__tests__/checkout-hold-service.test.ts
+++ b/packages/bookings-payments/__tests__/checkout-hold-service.test.ts
@@ -23,11 +23,12 @@ type HoldDoc = {
   id: number
   user: number
   timeslot: number
-  tenant: number
+  tenant?: number
   quantity: number
   expiresAt: string
   firstUpsertedAt?: string
   status: string
+  checkoutSessionId?: string
 }
 
 function iso(ms: number) {
@@ -85,14 +86,27 @@ describe('checkout hold service', () => {
           (c) => c.expiresAt && typeof c.expiresAt === 'object' && 'less_than_equal' in (c.expiresAt as object),
         )
 
-        if (statusEquals && (statusEquals.status as { equals?: string }).equals === 'active') {
-          if (expiresLte) {
-            filtered = filtered.filter((h) => h.status === 'active' && Date.parse(h.expiresAt) <= now)
-          } else if (expiresGt) {
-            filtered = filtered.filter((h) => h.status === 'active' && Date.parse(h.expiresAt) > now)
-          } else {
-            filtered = filtered.filter((h) => h.status === 'active')
+        if (statusEquals) {
+          const status = (statusEquals.status as { equals?: string }).equals
+          if (status === 'active') {
+            if (expiresLte) {
+              filtered = filtered.filter((h) => h.status === 'active' && Date.parse(h.expiresAt) <= now)
+            } else if (expiresGt) {
+              filtered = filtered.filter((h) => h.status === 'active' && Date.parse(h.expiresAt) > now)
+            } else {
+              filtered = filtered.filter((h) => h.status === 'active')
+            }
+          } else if (status) {
+            filtered = filtered.filter((h) => h.status === status)
           }
+        }
+
+        const sessionEquals = clauses.find(
+          (c) => c.checkoutSessionId && typeof c.checkoutSessionId === 'object',
+        )
+        if (sessionEquals) {
+          const sid = (sessionEquals.checkoutSessionId as { equals?: string }).equals
+          if (sid) filtered = filtered.filter((h) => h.checkoutSessionId === sid)
         }
 
         if (limit === 1) filtered = filtered.slice(0, 1)
@@ -231,7 +245,7 @@ describe('checkout hold service', () => {
   })
 
   describe('releaseCheckoutHold', () => {
-    it('deletes the user active hold for the timeslot', async () => {
+    it('marks the user active hold as released for the timeslot', async () => {
       holds.push({
         id: 7,
         user: USER_ID,
@@ -240,6 +254,7 @@ describe('checkout hold service', () => {
         quantity: 2,
         expiresAt: iso(now + HOLD_TTL_MS),
         status: 'active',
+        checkoutSessionId: 'sess-7',
       })
       const payload = makePayload()
 
@@ -249,7 +264,8 @@ describe('checkout hold service', () => {
       })
 
       expect(result.released).toBe(1)
-      expect(holds).toHaveLength(0)
+      expect(holds).toHaveLength(1)
+      expect(holds[0]!.status).toBe('released')
     })
 
     it('returns released 0 when no hold exists', async () => {
@@ -259,6 +275,50 @@ describe('checkout hold service', () => {
         userId: USER_ID,
       })
       expect(result.released).toBe(0)
+    })
+
+    it('plants a released tombstone when releasing a session before upsert completes', async () => {
+      const payload = makePayload()
+      const result = await releaseCheckoutHold(payload as never, {
+        timeslotId: TIMESLOT_ID,
+        userId: USER_ID,
+        checkoutSessionId: 'sess-early',
+      })
+      expect(result.released).toBe(1)
+      expect(holds).toHaveLength(1)
+      expect(holds[0]).toMatchObject({
+        status: 'released',
+        checkoutSessionId: 'sess-early',
+      })
+    })
+  })
+
+  describe('upsertCheckoutHold abandoned session', () => {
+    it('does not recreate an active hold after the same session was released', async () => {
+      holds.push({
+        id: 9,
+        user: USER_ID,
+        timeslot: TIMESLOT_ID,
+        tenant: TENANT_ID,
+        quantity: 1,
+        expiresAt: iso(now + HOLD_TTL_MS),
+        status: 'released',
+        checkoutSessionId: 'sess-abandon',
+      })
+      const payload = makePayload()
+
+      const result = await upsertCheckoutHold(payload as never, {
+        timeslotId: TIMESLOT_ID,
+        userId: USER_ID,
+        tenantId: TENANT_ID,
+        quantity: 1,
+        checkoutSessionId: 'sess-abandon',
+      })
+
+      expect(result.abandoned).toBe(true)
+      expect(result.quantity).toBe(0)
+      expect(holds.filter((h) => h.status === 'active')).toHaveLength(0)
+      expect(payload.create).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/bookings-payments/__tests__/checkout-hold-service.test.ts
+++ b/packages/bookings-payments/__tests__/checkout-hold-service.test.ts
@@ -321,6 +321,62 @@ describe('checkout hold service', () => {
       expect(holds.filter((h) => h.status === 'active')).toHaveLength(0)
       expect(payload.create).not.toHaveBeenCalled()
     })
+
+    it('does not recreate capacity when release wins after the initial abandoned check (TOCTOU)', async () => {
+      holds.push({
+        id: 42,
+        user: USER_ID,
+        timeslot: TIMESLOT_ID,
+        tenant: TENANT_ID,
+        quantity: 1,
+        expiresAt: iso(now),
+        status: 'released',
+        checkoutSessionId: 'sess-race',
+      })
+      const payload = makePayload()
+      let releasedSessionLookups = 0
+      const innerFind = payload.find
+      payload.find = vi.fn().mockImplementation(async (args: {
+        collection: string
+        where?: Record<string, unknown>
+        limit?: number
+      }) => {
+        const clauses = Array.isArray((args.where as { and?: unknown[] } | undefined)?.and)
+          ? ((args.where as { and: Record<string, unknown>[] }).and)
+          : []
+        const statusEquals = clauses.find((c) => c.status && typeof c.status === 'object')
+        const sessionEquals = clauses.find(
+          (c) => c.checkoutSessionId && typeof c.checkoutSessionId === 'object',
+        )
+        const lookingForReleasedSession =
+          args.collection === 'booking-checkout-holds' &&
+          (statusEquals?.status as { equals?: string } | undefined)?.equals === 'released' &&
+          Boolean((sessionEquals?.checkoutSessionId as { equals?: string } | undefined)?.equals)
+
+        if (lookingForReleasedSession) {
+          releasedSessionLookups += 1
+          // First check: pretend the session is still live (release hasn't landed yet).
+          if (releasedSessionLookups === 1) {
+            return { docs: [], totalDocs: 0 }
+          }
+        }
+        return innerFind(args)
+      })
+
+      const result = await upsertCheckoutHold(payload as never, {
+        timeslotId: TIMESLOT_ID,
+        userId: USER_ID,
+        tenantId: TENANT_ID,
+        quantity: 1,
+        checkoutSessionId: 'sess-race',
+      })
+
+      expect(result.abandoned).toBe(true)
+      expect(result.quantity).toBe(0)
+      expect(holds.filter((h) => h.status === 'active')).toHaveLength(0)
+      expect(payload.create).not.toHaveBeenCalled()
+      expect(releasedSessionLookups).toBeGreaterThanOrEqual(2)
+    })
   })
 
   describe('adjustCheckoutHoldQuantity', () => {

--- a/packages/bookings-payments/__tests__/checkout-hold-service.test.ts
+++ b/packages/bookings-payments/__tests__/checkout-hold-service.test.ts
@@ -306,7 +306,8 @@ describe('checkout hold service', () => {
 
       expect(result.holdId).toBe(1)
       expect(holds.filter((h) => h.status === 'active')).toHaveLength(1)
-      expect(holds.find((h) => h.id === 77)?.status).toBe('released')
+      expect(holds.find((h) => h.id === 77)?.status).toBe('expired')
+      expect(holds.find((h) => h.id === 77)?.checkoutSessionId ?? null).toBeNull()
     })
   })
 
@@ -385,6 +386,44 @@ describe('checkout hold service', () => {
       expect(result.quantity).toBe(0)
       expect(holds.filter((h) => h.status === 'active')).toHaveLength(0)
       expect(payload.create).not.toHaveBeenCalled()
+    })
+
+    it('clears leftover active holds when the session tombstone already exists', async () => {
+      holds.push(
+        {
+          id: 9,
+          user: USER_ID,
+          timeslot: TIMESLOT_ID,
+          tenant: TENANT_ID,
+          quantity: 1,
+          expiresAt: iso(now + HOLD_TTL_MS),
+          status: 'released',
+          checkoutSessionId: 'sess-abandon',
+        },
+        {
+          id: 10,
+          user: USER_ID,
+          timeslot: TIMESLOT_ID,
+          tenant: TENANT_ID,
+          quantity: 1,
+          expiresAt: iso(now + HOLD_TTL_MS),
+          status: 'active',
+          checkoutSessionId: 'sess-other',
+        },
+      )
+      const payload = makePayload()
+
+      const result = await upsertCheckoutHold(payload as never, {
+        timeslotId: TIMESLOT_ID,
+        userId: USER_ID,
+        tenantId: TENANT_ID,
+        quantity: 1,
+        checkoutSessionId: 'sess-abandon',
+      })
+
+      expect(result.abandoned).toBe(true)
+      expect(holds.find((h) => h.id === 10)?.status).toBe('released')
+      expect(holds.filter((h) => h.status === 'active')).toHaveLength(0)
     })
 
     it('does not recreate capacity when release wins after the initial abandoned check (TOCTOU)', async () => {

--- a/packages/bookings-payments/__tests__/checkout-hold-service.test.ts
+++ b/packages/bookings-payments/__tests__/checkout-hold-service.test.ts
@@ -110,6 +110,16 @@ describe('checkout hold service', () => {
           if (sid) filtered = filtered.filter((h) => h.checkoutSessionId === sid)
         }
 
+        const idNotEquals = clauses.find(
+          (c) => c.id && typeof c.id === 'object' && 'not_equals' in (c.id as object),
+        )
+        if (idNotEquals) {
+          const skipId = (idNotEquals.id as { not_equals?: number }).not_equals
+          if (typeof skipId === 'number') {
+            filtered = filtered.filter((h) => h.id !== skipId)
+          }
+        }
+
         if (limit === 1) filtered = filtered.slice(0, 1)
         return Promise.resolve({ docs: filtered, totalDocs: filtered.length })
       }),
@@ -242,6 +252,61 @@ describe('checkout hold service', () => {
       })
 
       expect(result.quantity).toBe(1)
+    })
+
+    it('releases duplicate active holds created by a concurrent race', async () => {
+      // Simulate TOCTOU: another create landed while this upsert was in flight.
+      holds.push({
+        id: 77,
+        user: USER_ID,
+        timeslot: TIMESLOT_ID,
+        tenant: TENANT_ID,
+        quantity: 1,
+        expiresAt: iso(now + HOLD_TTL_MS),
+        firstUpsertedAt: iso(now),
+        status: 'active',
+        checkoutSessionId: 'session-a',
+      })
+      const payload = makePayload()
+      // First findUserActiveHold returns null (race window), then create, then collapse.
+      let userActiveLookups = 0
+      const originalFind = payload.find
+      payload.find = vi.fn().mockImplementation(async (args: Parameters<typeof originalFind>[0]) => {
+        const result = await originalFind(args)
+        const clauses = Array.isArray((args.where as { and?: unknown[] } | undefined)?.and)
+          ? ((args.where as { and: Record<string, unknown>[] }).and)
+          : []
+        const userEquals = clauses.find((c) => c.user && typeof c.user === 'object')
+        const statusEquals = clauses.find((c) => c.status && typeof c.status === 'object')
+        const idNotEquals = clauses.find(
+          (c) => c.id && typeof c.id === 'object' && 'not_equals' in (c.id as object),
+        )
+        if (
+          userEquals &&
+          statusEquals &&
+          (statusEquals.status as { equals?: string }).equals === 'active' &&
+          !idNotEquals &&
+          args.limit === 1
+        ) {
+          userActiveLookups += 1
+          if (userActiveLookups === 1) {
+            return { docs: [], totalDocs: 0 }
+          }
+        }
+        return result
+      })
+
+      const result = await upsertCheckoutHold(payload as never, {
+        timeslotId: TIMESLOT_ID,
+        userId: USER_ID,
+        tenantId: TENANT_ID,
+        quantity: 1,
+        checkoutSessionId: 'session-b',
+      })
+
+      expect(result.holdId).toBe(1)
+      expect(holds.filter((h) => h.status === 'active')).toHaveLength(1)
+      expect(holds.find((h) => h.id === 77)?.status).toBe('released')
     })
   })
 

--- a/packages/bookings-payments/__tests__/compute-enrollment-access-window.test.ts
+++ b/packages/bookings-payments/__tests__/compute-enrollment-access-window.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Course enrollment access window: fixed product dates OR duration from purchase.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  computeEnrollmentAccessWindow,
+  resolveCourseDurationMode,
+} from "../src/course/utilities/compute-enrollment-access-window";
+
+describe("resolveCourseDurationMode", () => {
+  it("returns fixed when startDate and endDate are set", () => {
+    expect(
+      resolveCourseDurationMode({
+        startDate: "2026-09-01",
+        endDate: "2026-10-26",
+      }),
+    ).toBe("fixed");
+  });
+
+  it("returns duration when durationLength and durationUnit are set", () => {
+    expect(
+      resolveCourseDurationMode({
+        durationLength: 8,
+        durationUnit: "weeks",
+      }),
+    ).toBe("duration");
+  });
+
+  it("returns invalid when both modes are set", () => {
+    expect(
+      resolveCourseDurationMode({
+        startDate: "2026-09-01",
+        endDate: "2026-10-26",
+        durationLength: 8,
+        durationUnit: "weeks",
+      }),
+    ).toBe("invalid");
+  });
+
+  it("returns invalid when neither mode is set", () => {
+    expect(resolveCourseDurationMode({})).toBe("invalid");
+  });
+
+  it("returns invalid when only one date is set", () => {
+    expect(resolveCourseDurationMode({ startDate: "2026-09-01" })).toBe("invalid");
+    expect(resolveCourseDurationMode({ endDate: "2026-10-26" })).toBe("invalid");
+  });
+
+  it("returns invalid when durationLength is missing or < 1", () => {
+    expect(resolveCourseDurationMode({ durationUnit: "weeks" })).toBe("invalid");
+    expect(
+      resolveCourseDurationMode({ durationLength: 0, durationUnit: "weeks" }),
+    ).toBe("invalid");
+  });
+});
+
+describe("computeEnrollmentAccessWindow", () => {
+  it("stamps fixed dates onto the enrollment window", () => {
+    const purchasedAt = new Date("2026-08-01T15:00:00.000Z");
+    expect(
+      computeEnrollmentAccessWindow(
+        { startDate: "2026-09-01", endDate: "2026-10-26" },
+        purchasedAt,
+      ),
+    ).toEqual({
+      accessStartsAt: "2026-09-01T00:00:00.000Z",
+      accessEndsAt: "2026-10-26T23:59:59.999Z",
+    });
+  });
+
+  it("stamps duration in weeks from purchasedAt", () => {
+    const purchasedAt = new Date("2026-07-29T12:00:00.000Z");
+    const result = computeEnrollmentAccessWindow(
+      { durationLength: 8, durationUnit: "weeks" },
+      purchasedAt,
+    );
+    expect(result.accessStartsAt).toBe(purchasedAt.toISOString());
+    const expectedEnd = new Date(purchasedAt);
+    expectedEnd.setUTCDate(expectedEnd.getUTCDate() + 8 * 7);
+    expect(result.accessEndsAt).toBe(expectedEnd.toISOString());
+  });
+
+  it("stamps duration in days from purchasedAt", () => {
+    const purchasedAt = new Date("2026-07-29T12:00:00.000Z");
+    const result = computeEnrollmentAccessWindow(
+      { durationLength: 14, durationUnit: "days" },
+      purchasedAt,
+    );
+    expect(result.accessStartsAt).toBe(purchasedAt.toISOString());
+    const expectedEnd = new Date(purchasedAt);
+    expectedEnd.setUTCDate(expectedEnd.getUTCDate() + 14);
+    expect(result.accessEndsAt).toBe(expectedEnd.toISOString());
+  });
+
+  it("throws when course duration mode is invalid", () => {
+    expect(() =>
+      computeEnrollmentAccessWindow({}, new Date("2026-07-29T12:00:00.000Z")),
+    ).toThrow(/duration mode/i);
+  });
+
+  it("throws when fixed endDate is before startDate", () => {
+    expect(() =>
+      computeEnrollmentAccessWindow(
+        { startDate: "2026-10-26", endDate: "2026-09-01" },
+        new Date("2026-07-29T12:00:00.000Z"),
+      ),
+    ).toThrow(/endDate/i);
+  });
+});

--- a/packages/bookings-payments/__tests__/config-shorthand.test.ts
+++ b/packages/bookings-payments/__tests__/config-shorthand.test.ts
@@ -127,4 +127,24 @@ describe("config shorthand (true | object)", () => {
     expect(slugs).toContain("plans");
     expect(slugs).toContain("subscriptions");
   });
+
+  it("accepts courses: true and enables courses + course-enrollments with allowedCourses injection", () => {
+    const plugin = bookingsPaymentsPlugin({
+      courses: true,
+    });
+    const incoming: Partial<Config> = { collections: baseCollections };
+    const result = plugin(incoming as Config) as Config;
+    const slugs = result.collections?.map((c) => c.slug) ?? [];
+    expect(slugs).toContain("courses");
+    expect(slugs).toContain("course-enrollments");
+    expect(slugs).toContain("transactions");
+
+    const eventTypes = result.collections?.find((c) => c.slug === "event-types");
+    const group = eventTypes?.fields?.find(
+      (f) => f.type === "group" && "name" in f && f.name === "paymentMethods",
+    );
+    const fields =
+      group && "fields" in group ? (group.fields as Array<{ name?: string }>) : [];
+    expect(fields.some((f) => f.name === "allowedCourses")).toBe(true);
+  });
 });

--- a/packages/bookings-payments/__tests__/validate-course-duration-mode.test.ts
+++ b/packages/bookings-payments/__tests__/validate-course-duration-mode.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { validateCourseDurationMode } from "../src/course/utilities/validate-course-duration-mode";
+
+describe("validateCourseDurationMode", () => {
+  it("accepts fixed dates", () => {
+    expect(
+      validateCourseDurationMode({
+        startDate: "2026-09-01",
+        endDate: "2026-10-26",
+      }),
+    ).toBe(true);
+  });
+
+  it("accepts duration weeks", () => {
+    expect(
+      validateCourseDurationMode({
+        durationLength: 8,
+        durationUnit: "weeks",
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects neither mode", () => {
+    expect(validateCourseDurationMode({})).toMatch(/fixed dates.*or a duration/i);
+  });
+
+  it("rejects both modes", () => {
+    expect(
+      validateCourseDurationMode({
+        startDate: "2026-09-01",
+        endDate: "2026-10-26",
+        durationLength: 8,
+        durationUnit: "weeks",
+      }),
+    ).toMatch(/not both/i);
+  });
+
+  it("rejects end before start", () => {
+    expect(
+      validateCourseDurationMode({
+        startDate: "2026-10-26",
+        endDate: "2026-09-01",
+      }),
+    ).toMatch(/endDate/i);
+  });
+});

--- a/packages/bookings-payments/src/checkout-holds/constants.ts
+++ b/packages/bookings-payments/src/checkout-holds/constants.ts
@@ -16,5 +16,5 @@ export const TIMESLOTS_COLLECTION_SLUG = 'timeslots' as CollectionSlug
 export const EVENT_TYPES_COLLECTION_SLUG = 'event-types' as CollectionSlug
 export const TRANSACTIONS_COLLECTION_SLUG = 'transactions' as CollectionSlug
 
-export const CHECKOUT_HOLD_STATUSES = ['active', 'consumed', 'expired'] as const
+export const CHECKOUT_HOLD_STATUSES = ['active', 'consumed', 'expired', 'released'] as const
 export type CheckoutHoldStatus = (typeof CHECKOUT_HOLD_STATUSES)[number]

--- a/packages/bookings-payments/src/checkout-holds/service.ts
+++ b/packages/bookings-payments/src/checkout-holds/service.ts
@@ -438,6 +438,33 @@ export async function upsertCheckoutHold(
     }
   }
 
+  // Concurrent Continue + CheckoutForm / restore races can create two active rows for the
+  // same user+timeslot (find-then-create is not atomic). Keep this row; release extras.
+  const duplicates = await payload.find({
+    collection: holdCollection,
+    where: {
+      and: [
+        { timeslot: { equals: opts.timeslotId } },
+        { user: { equals: userId } },
+        { status: { equals: 'active' } },
+        { expiresAt: { greater_than: new Date().toISOString() } },
+        { id: { not_equals: created.id } },
+      ],
+    },
+    limit: 100,
+    depth: 0,
+    overrideAccess: true,
+  })
+  for (const dup of (duplicates.docs ?? []) as CheckoutHoldRecord[]) {
+    if (dup.id === created.id) continue
+    await payload.update({
+      collection: holdCollection,
+      id: dup.id,
+      data: { status: 'released' },
+      overrideAccess: true,
+    })
+  }
+
   return {
     holdId: created.id,
     quantity: created.quantity,

--- a/packages/bookings-payments/src/checkout-holds/service.ts
+++ b/packages/bookings-payments/src/checkout-holds/service.ts
@@ -532,7 +532,17 @@ export async function getActiveCheckoutHold(
   )
 }
 
-export async function computeRemainingCapacityWithHolds(
+export type CapacityWithHoldsBreakdown = {
+  places: number
+  confirmed: number
+  held: number
+  /** places − confirmed − active holds (global free spots for new checkouts). */
+  remaining: number
+  /** places − confirmed only — true sell-out; unpaid holds must not hard-sold-out the page. */
+  remainingConfirmedOnly: number
+}
+
+export async function computeCapacityBreakdownWithHolds(
   payload: PayloadLike,
   timeslotId: number,
   slugs?: {
@@ -541,7 +551,7 @@ export async function computeRemainingCapacityWithHolds(
     bookingsSlug?: CollectionSlug
     holdCollection?: CollectionSlug
   },
-): Promise<number> {
+): Promise<CapacityWithHoldsBreakdown> {
   await expireStaleActiveHolds(payload, {
     timeslotId,
     holdCollection: slugs?.holdCollection,
@@ -559,5 +569,25 @@ export async function computeRemainingCapacityWithHolds(
     timeslotId,
     slugs?.holdCollection,
   )
-  return Math.max(0, places - confirmed - held)
+  return {
+    places,
+    confirmed,
+    held,
+    remaining: Math.max(0, places - confirmed - held),
+    remainingConfirmedOnly: Math.max(0, places - confirmed),
+  }
+}
+
+export async function computeRemainingCapacityWithHolds(
+  payload: PayloadLike,
+  timeslotId: number,
+  slugs?: {
+    timeslotsSlug?: CollectionSlug
+    eventTypesSlug?: CollectionSlug
+    bookingsSlug?: CollectionSlug
+    holdCollection?: CollectionSlug
+  },
+): Promise<number> {
+  const breakdown = await computeCapacityBreakdownWithHolds(payload, timeslotId, slugs)
+  return breakdown.remaining
 }

--- a/packages/bookings-payments/src/checkout-holds/service.ts
+++ b/packages/bookings-payments/src/checkout-holds/service.ts
@@ -21,6 +21,7 @@ export type CheckoutHoldRecord = {
   expiresAt: string
   firstUpsertedAt?: string
   status: CheckoutHoldStatus | string
+  checkoutSessionId?: string | null
   stripePaymentIntentId?: string | null
   failureReason?: string | null
 }
@@ -29,6 +30,8 @@ export type UpsertCheckoutHoldResult = {
   holdId: number
   quantity: number
   expiresAt: string
+  /** True when this checkoutSessionId was already released — no active hold created. */
+  abandoned?: boolean
 }
 
 function relationId(value: number | { id: number } | null | undefined): number | null {
@@ -208,6 +211,30 @@ async function findUserActiveHold(
   return (result.docs?.[0] as CheckoutHoldRecord | undefined) ?? null
 }
 
+async function findReleasedHoldForSession(
+  payload: PayloadLike,
+  opts: { timeslotId: number; userId: number; checkoutSessionId: string },
+  holdCollection: CollectionSlug = CHECKOUT_HOLD_COLLECTION_SLUG,
+): Promise<CheckoutHoldRecord | null> {
+  const sessionId = opts.checkoutSessionId.trim()
+  if (!sessionId) return null
+  const result = await payload.find({
+    collection: holdCollection,
+    where: {
+      and: [
+        { timeslot: { equals: opts.timeslotId } },
+        { user: { equals: opts.userId } },
+        { checkoutSessionId: { equals: sessionId } },
+        { status: { equals: 'released' } },
+      ],
+    },
+    limit: 1,
+    depth: 0,
+    overrideAccess: true,
+  })
+  return (result.docs?.[0] as CheckoutHoldRecord | undefined) ?? null
+}
+
 async function assertCapacityForHold(
   payload: PayloadLike,
   opts: {
@@ -257,6 +284,8 @@ export async function upsertCheckoutHold(
     userId: number
     tenantId: number
     quantity: number
+    /** Client attempt id — ignored if this session was already released. */
+    checkoutSessionId?: string | null
     holdCollection?: CollectionSlug
     timeslotsSlug?: CollectionSlug
     eventTypesSlug?: CollectionSlug
@@ -269,11 +298,32 @@ export async function upsertCheckoutHold(
   const nowMs = Date.now()
   const expiresAt = expiresAtFromNow(nowMs)
   const tenantContext = tenantContextForHold(opts.tenantId)
+  const checkoutSessionId =
+    typeof opts.checkoutSessionId === 'string' && opts.checkoutSessionId.trim()
+      ? opts.checkoutSessionId.trim()
+      : null
 
   await expireStaleActiveHolds(payload, {
     timeslotId: opts.timeslotId,
     holdCollection,
   })
+
+  // Late in-flight reserves after page exit must not recreate capacity.
+  if (checkoutSessionId) {
+    const abandoned = await findReleasedHoldForSession(
+      payload,
+      { timeslotId: opts.timeslotId, userId, checkoutSessionId },
+      holdCollection,
+    )
+    if (abandoned) {
+      return {
+        holdId: abandoned.id,
+        quantity: 0,
+        expiresAt: abandoned.expiresAt,
+        abandoned: true,
+      }
+    }
+  }
 
   const existing = await findUserActiveHold(
     payload,
@@ -300,6 +350,7 @@ export async function upsertCheckoutHold(
         quantity,
         expiresAt,
         tenant: opts.tenantId,
+        ...(checkoutSessionId ? { checkoutSessionId } : {}),
       },
       context: tenantContext,
       overrideAccess: true,
@@ -322,6 +373,7 @@ export async function upsertCheckoutHold(
       expiresAt,
       firstUpsertedAt: new Date(nowMs).toISOString(),
       status: 'active',
+      ...(checkoutSessionId ? { checkoutSessionId } : {}),
     },
     context: tenantContext,
     overrideAccess: true,
@@ -356,10 +408,19 @@ export async function releaseCheckoutHold(
     timeslotId: number
     userId: number
     holdCollection?: CollectionSlug
+    /**
+     * When provided and no active hold exists yet, write a released tombstone so a
+     * late upsert for this session cannot recreate capacity after leave.
+     */
+    checkoutSessionId?: string | null
   },
 ): Promise<{ released: number }> {
   const holdCollection = opts.holdCollection ?? CHECKOUT_HOLD_COLLECTION_SLUG
   const nowIso = new Date().toISOString()
+  const checkoutSessionId =
+    typeof opts.checkoutSessionId === 'string' && opts.checkoutSessionId.trim()
+      ? opts.checkoutSessionId.trim()
+      : null
 
   const active = await payload.find({
     collection: holdCollection,
@@ -378,11 +439,47 @@ export async function releaseCheckoutHold(
 
   const docs = (active.docs ?? []) as CheckoutHoldRecord[]
   for (const doc of docs) {
-    await payload.delete({
+    // Mark released (keep session id) so late in-flight upserts for this attempt are no-ops.
+    await payload.update({
       collection: holdCollection,
       id: doc.id,
+      data: {
+        status: 'released',
+        ...(checkoutSessionId && !doc.checkoutSessionId
+          ? { checkoutSessionId }
+          : {}),
+      },
       overrideAccess: true,
     })
+  }
+
+  if (docs.length === 0 && checkoutSessionId) {
+    const already = await findReleasedHoldForSession(
+      payload,
+      {
+        timeslotId: opts.timeslotId,
+        userId: opts.userId,
+        checkoutSessionId,
+      },
+      holdCollection,
+    )
+    if (!already) {
+      // Race: release arrived before the first upsert finished. Plant a tombstone.
+      await payload.create({
+        collection: holdCollection,
+        data: {
+          user: opts.userId,
+          timeslot: opts.timeslotId,
+          quantity: 1,
+          expiresAt: nowIso,
+          firstUpsertedAt: nowIso,
+          status: 'released',
+          checkoutSessionId,
+        },
+        overrideAccess: true,
+      })
+      return { released: 1 }
+    }
   }
 
   return { released: docs.length }

--- a/packages/bookings-payments/src/checkout-holds/service.ts
+++ b/packages/bookings-payments/src/checkout-holds/service.ts
@@ -343,6 +343,23 @@ export async function upsertCheckoutHold(
   })
 
   if (existing) {
+    // Release may have won the race after findUserActiveHold — don't revive capacity.
+    if (checkoutSessionId) {
+      const abandonedBeforeUpdate = await findReleasedHoldForSession(
+        payload,
+        { timeslotId: opts.timeslotId, userId, checkoutSessionId },
+        holdCollection,
+      )
+      if (abandonedBeforeUpdate) {
+        return {
+          holdId: abandonedBeforeUpdate.id,
+          quantity: 0,
+          expiresAt: abandonedBeforeUpdate.expiresAt,
+          abandoned: true,
+        }
+      }
+    }
+
     const updated = (await payload.update({
       collection: holdCollection,
       id: existing.id,
@@ -363,6 +380,25 @@ export async function upsertCheckoutHold(
     }
   }
 
+  // TOCTOU: unload release can mark the session released after the initial abandoned
+  // check and after findUserActiveHold returned null. Re-check before creating capacity
+  // so a late in-flight reserve cannot recreate an active hold after tab close.
+  if (checkoutSessionId) {
+    const abandonedBeforeCreate = await findReleasedHoldForSession(
+      payload,
+      { timeslotId: opts.timeslotId, userId, checkoutSessionId },
+      holdCollection,
+    )
+    if (abandonedBeforeCreate) {
+      return {
+        holdId: abandonedBeforeCreate.id,
+        quantity: 0,
+        expiresAt: abandonedBeforeCreate.expiresAt,
+        abandoned: true,
+      }
+    }
+  }
+
   const created = (await payload.create({
     collection: holdCollection,
     data: {
@@ -378,6 +414,29 @@ export async function upsertCheckoutHold(
     context: tenantContext,
     overrideAccess: true,
   })) as CheckoutHoldRecord
+
+  // Narrow window: release/tombstone landed between the re-check and create.
+  if (checkoutSessionId) {
+    const abandonedAfterCreate = await findReleasedHoldForSession(
+      payload,
+      { timeslotId: opts.timeslotId, userId, checkoutSessionId },
+      holdCollection,
+    )
+    if (abandonedAfterCreate && abandonedAfterCreate.id !== created.id) {
+      await payload.update({
+        collection: holdCollection,
+        id: created.id,
+        data: { status: 'released', checkoutSessionId },
+        overrideAccess: true,
+      })
+      return {
+        holdId: abandonedAfterCreate.id,
+        quantity: 0,
+        expiresAt: abandonedAfterCreate.expiresAt,
+        abandoned: true,
+      }
+    }
+  }
 
   return {
     holdId: created.id,

--- a/packages/bookings-payments/src/checkout-holds/service.ts
+++ b/packages/bookings-payments/src/checkout-holds/service.ts
@@ -316,6 +316,13 @@ export async function upsertCheckoutHold(
       holdCollection,
     )
     if (abandoned) {
+      // A concurrent create may still be active beside the tombstone — clear it.
+      await releaseActiveHoldsForUserTimeslot(payload, {
+        timeslotId: opts.timeslotId,
+        userId,
+        holdCollection,
+        checkoutSessionId,
+      })
       return {
         holdId: abandoned.id,
         quantity: 0,
@@ -351,6 +358,12 @@ export async function upsertCheckoutHold(
         holdCollection,
       )
       if (abandonedBeforeUpdate) {
+        await releaseActiveHoldsForUserTimeslot(payload, {
+          timeslotId: opts.timeslotId,
+          userId,
+          holdCollection,
+          checkoutSessionId,
+        })
         return {
           holdId: abandonedBeforeUpdate.id,
           quantity: 0,
@@ -360,23 +373,97 @@ export async function upsertCheckoutHold(
       }
     }
 
-    const updated = (await payload.update({
-      collection: holdCollection,
-      id: existing.id,
-      data: {
-        quantity,
-        expiresAt,
-        tenant: opts.tenantId,
-        ...(checkoutSessionId ? { checkoutSessionId } : {}),
-      },
-      context: tenantContext,
-      overrideAccess: true,
-    })) as CheckoutHoldRecord
+    // Re-read: unload release can flip this row to released between checks and update.
+    const stillActive = await findUserActiveHold(
+      payload,
+      { timeslotId: opts.timeslotId, userId },
+      holdCollection,
+    )
+    if (!stillActive || stillActive.id !== existing.id) {
+      if (checkoutSessionId) {
+        const abandonedAfterRace = await findReleasedHoldForSession(
+          payload,
+          { timeslotId: opts.timeslotId, userId, checkoutSessionId },
+          holdCollection,
+        )
+        if (abandonedAfterRace) {
+          return {
+            holdId: abandonedAfterRace.id,
+            quantity: 0,
+            expiresAt: abandonedAfterRace.expiresAt,
+            abandoned: true,
+          }
+        }
+      }
+      // Fall through to create with a fresh row.
+    } else {
+      const updated = (await payload.update({
+        collection: holdCollection,
+        id: existing.id,
+        data: {
+          quantity,
+          expiresAt,
+          tenant: opts.tenantId,
+          // Do not set status: 'active' — that would revive a row released between
+          // stillActive and this write.
+          ...(checkoutSessionId ? { checkoutSessionId } : {}),
+        },
+        context: tenantContext,
+        overrideAccess: true,
+      })) as CheckoutHoldRecord
 
-    return {
-      holdId: updated.id,
-      quantity: updated.quantity,
-      expiresAt: updated.expiresAt,
+      // If unload release won, this row is released (update did not flip status).
+      if (!isHoldActive(updated)) {
+        if (checkoutSessionId) {
+          const abandonedReleased = await findReleasedHoldForSession(
+            payload,
+            { timeslotId: opts.timeslotId, userId, checkoutSessionId },
+            holdCollection,
+          )
+          if (abandonedReleased) {
+            return {
+              holdId: abandonedReleased.id,
+              quantity: 0,
+              expiresAt: abandonedReleased.expiresAt,
+              abandoned: true,
+            }
+          }
+        }
+        // Unexpected non-active state — treat as no hold and fall through to create.
+      } else if (checkoutSessionId) {
+        // Unload release may have planted a tombstone (different row) during the update.
+        const abandonedAfterUpdate = await findReleasedHoldForSession(
+          payload,
+          { timeslotId: opts.timeslotId, userId, checkoutSessionId },
+          holdCollection,
+        )
+        if (abandonedAfterUpdate && abandonedAfterUpdate.id !== updated.id) {
+          await payload.update({
+            collection: holdCollection,
+            id: updated.id,
+            data: { status: 'released', checkoutSessionId },
+            overrideAccess: true,
+          })
+          return {
+            holdId: abandonedAfterUpdate.id,
+            quantity: 0,
+            expiresAt: abandonedAfterUpdate.expiresAt,
+            abandoned: true,
+          }
+        }
+
+        return {
+          holdId: updated.id,
+          quantity: updated.quantity,
+          expiresAt: updated.expiresAt,
+        }
+      } else {
+        return {
+          holdId: updated.id,
+          quantity: updated.quantity,
+          expiresAt: updated.expiresAt,
+        }
+      }
     }
   }
 
@@ -390,6 +477,12 @@ export async function upsertCheckoutHold(
       holdCollection,
     )
     if (abandonedBeforeCreate) {
+      await releaseActiveHoldsForUserTimeslot(payload, {
+        timeslotId: opts.timeslotId,
+        userId,
+        holdCollection,
+        checkoutSessionId,
+      })
       return {
         holdId: abandonedBeforeCreate.id,
         quantity: 0,
@@ -438,8 +531,9 @@ export async function upsertCheckoutHold(
     }
   }
 
-  // Concurrent Continue + CheckoutForm / restore races can create two active rows for the
-  // same user+timeslot (find-then-create is not atomic). Keep this row; release extras.
+  // Concurrent Continue + CheckoutForm races can create two active rows for the same
+  // user+timeslot. Expire extras (not `released`) so we don't plant same-session
+  // tombstones that confuse findReleasedHoldForSession beside an active winner.
   const duplicates = await payload.find({
     collection: holdCollection,
     where: {
@@ -460,7 +554,11 @@ export async function upsertCheckoutHold(
     await payload.update({
       collection: holdCollection,
       id: dup.id,
-      data: { status: 'released' },
+      data: {
+        status: 'expired',
+        checkoutSessionId: null,
+        expiresAt: new Date().toISOString(),
+      },
       overrideAccess: true,
     })
   }
@@ -469,6 +567,43 @@ export async function upsertCheckoutHold(
     holdId: created.id,
     quantity: created.quantity,
     expiresAt: created.expiresAt,
+  }
+}
+
+async function releaseActiveHoldsForUserTimeslot(
+  payload: PayloadLike,
+  opts: {
+    timeslotId: number
+    userId: number
+    holdCollection: CollectionSlug
+    checkoutSessionId?: string | null
+  },
+): Promise<void> {
+  const nowIso = new Date().toISOString()
+  const active = await payload.find({
+    collection: opts.holdCollection,
+    where: {
+      and: [
+        { timeslot: { equals: opts.timeslotId } },
+        { user: { equals: opts.userId } },
+        { status: { equals: 'active' } },
+        { expiresAt: { greater_than: nowIso } },
+      ],
+    },
+    limit: 100,
+    depth: 0,
+    overrideAccess: true,
+  })
+  for (const doc of (active.docs ?? []) as CheckoutHoldRecord[]) {
+    await payload.update({
+      collection: opts.holdCollection,
+      id: doc.id,
+      data: {
+        status: 'released',
+        ...(opts.checkoutSessionId ? { checkoutSessionId: opts.checkoutSessionId } : {}),
+      },
+      overrideAccess: true,
+    })
   }
 }
 
@@ -525,15 +660,14 @@ export async function releaseCheckoutHold(
 
   const docs = (active.docs ?? []) as CheckoutHoldRecord[]
   for (const doc of docs) {
-    // Mark released (keep session id) so late in-flight upserts for this attempt are no-ops.
+    // Always stamp the leaving session id so late upserts for this attempt are no-ops,
+    // even if a concurrent upsert overwrote checkoutSessionId mid-flight.
     await payload.update({
       collection: holdCollection,
       id: doc.id,
       data: {
         status: 'released',
-        ...(checkoutSessionId && !doc.checkoutSessionId
-          ? { checkoutSessionId }
-          : {}),
+        ...(checkoutSessionId ? { checkoutSessionId } : {}),
       },
       overrideAccess: true,
     })

--- a/packages/bookings-payments/src/collections/booking-checkout-holds.ts
+++ b/packages/bookings-payments/src/collections/booking-checkout-holds.ts
@@ -61,6 +61,16 @@ const defaultFields: NonNullable<CollectionConfig['fields']> = [
     index: true,
   },
   {
+    name: 'checkoutSessionId',
+    type: 'text',
+    required: false,
+    index: true,
+    admin: {
+      description:
+        'Client checkout attempt id. After release, upserts with the same id are ignored so late in-flight reserves cannot recreate capacity holds.',
+    },
+  },
+  {
     name: 'stripePaymentIntentId',
     type: 'text',
     required: false,

--- a/packages/bookings-payments/src/course/access/course-enrollments.ts
+++ b/packages/bookings-payments/src/course/access/course-enrollments.ts
@@ -1,0 +1,24 @@
+import type { Access } from "payload";
+import { checkRole } from "@repo/shared-utils";
+import type { User } from "@repo/shared-types";
+
+export const courseEnrollmentsReadAccess: Access = ({ req: { user } }) => {
+  if (!user) return false;
+  if (checkRole(["admin"], user as unknown as User)) return true;
+  return { user: { equals: user.id } };
+};
+
+export const courseEnrollmentsCreateAccess: Access = ({ req: { user } }) => {
+  if (!user) return false;
+  return checkRole(["admin"], user as unknown as User);
+};
+
+export const courseEnrollmentsUpdateAccess: Access = ({ req: { user } }) => {
+  if (!user) return false;
+  return checkRole(["admin"], user as unknown as User);
+};
+
+export const courseEnrollmentsDeleteAccess: Access = ({ req: { user } }) => {
+  if (!user) return false;
+  return checkRole(["admin"], user as unknown as User);
+};

--- a/packages/bookings-payments/src/course/access/courses.ts
+++ b/packages/bookings-payments/src/course/access/courses.ts
@@ -1,0 +1,17 @@
+import type { Access } from "payload";
+import { checkRole } from "@repo/shared-utils";
+import type { User } from "@repo/shared-types";
+
+export const coursesReadAccess: Access = () => true;
+export const coursesCreateAccess: Access = ({ req: { user } }) => {
+  if (!user) return false;
+  return checkRole(["admin"], user as unknown as User);
+};
+export const coursesUpdateAccess: Access = ({ req: { user } }) => {
+  if (!user) return false;
+  return checkRole(["admin"], user as unknown as User);
+};
+export const coursesDeleteAccess: Access = ({ req: { user } }) => {
+  if (!user) return false;
+  return checkRole(["admin"], user as unknown as User);
+};

--- a/packages/bookings-payments/src/course/collections/course-enrollments.ts
+++ b/packages/bookings-payments/src/course/collections/course-enrollments.ts
@@ -1,0 +1,116 @@
+import type { CollectionConfig, Field } from "payload";
+import {
+  courseEnrollmentsReadAccess,
+  courseEnrollmentsCreateAccess,
+  courseEnrollmentsUpdateAccess,
+  courseEnrollmentsDeleteAccess,
+} from "../access/course-enrollments";
+import type { CollectionOverrides } from "../../types";
+
+const STATUS_OPTIONS = ["active", "cancelled", "completed"] as const;
+
+export type CourseEnrollmentsOpts = {
+  adminGroup?: string;
+  overrides?: CollectionOverrides;
+};
+
+const defaultAccess: NonNullable<CollectionConfig["access"]> = {
+  read: courseEnrollmentsReadAccess,
+  create: courseEnrollmentsCreateAccess,
+  update: courseEnrollmentsUpdateAccess,
+  delete: courseEnrollmentsDeleteAccess,
+};
+
+export function courseEnrollmentsCollection(
+  opts: CourseEnrollmentsOpts = {},
+): CollectionConfig {
+  const adminGroup = opts.adminGroup ?? "Billing";
+  const overrides = opts.overrides;
+
+  const defaultFields: Field[] = [
+    {
+      name: "user",
+      label: "User",
+      type: "relationship",
+      relationTo: "users",
+      required: true,
+      admin: { description: "Enrolled user" },
+    },
+    {
+      name: "course",
+      label: "Course",
+      type: "relationship",
+      relationTo: "courses" as import("payload").CollectionSlug,
+      required: true,
+      admin: { description: "Course purchased" },
+    },
+    {
+      name: "status",
+      label: "Status",
+      type: "select",
+      options: [...STATUS_OPTIONS],
+      defaultValue: "active",
+      required: true,
+    },
+    {
+      name: "purchasedAt",
+      label: "Purchased at",
+      type: "date",
+      required: true,
+      admin: { description: "When the course was purchased" },
+    },
+    {
+      name: "accessStartsAt",
+      label: "Access starts at",
+      type: "date",
+      required: true,
+      admin: {
+        description: "Start of booking access window (stamped at purchase)",
+        date: { pickerAppearance: "dayAndTime" },
+      },
+    },
+    {
+      name: "accessEndsAt",
+      label: "Access ends at",
+      type: "date",
+      required: true,
+      admin: {
+        description: "End of booking access window (stamped at purchase)",
+        date: { pickerAppearance: "dayAndTime" },
+      },
+    },
+    {
+      name: "transactionId",
+      label: "Transaction ID",
+      type: "text",
+      required: false,
+      admin: {
+        description: "External transaction id (e.g. Stripe payment intent id).",
+      },
+    },
+  ];
+
+  const access = overrides?.access
+    ? { ...defaultAccess, ...overrides.access }
+    : defaultAccess;
+  const fields = overrides?.fields
+    ? overrides.fields({ defaultFields: [...defaultFields] })
+    : defaultFields;
+  const hooks = overrides?.hooks
+    ? overrides.hooks({ defaultHooks: {} })
+    : undefined;
+
+  return {
+    slug: "course-enrollments",
+    labels: { singular: "Course Enrollment", plural: "Course Enrollments" },
+    admin: {
+      useAsTitle: "id",
+      defaultColumns: ["user", "course", "status", "accessStartsAt", "accessEndsAt"],
+      group: adminGroup,
+      description: "Purchased course enrollments with stamped access windows",
+    },
+    access,
+    fields,
+    ...(hooks ? { hooks } : {}),
+  };
+}

--- a/packages/bookings-payments/src/course/collections/courses.ts
+++ b/packages/bookings-payments/src/course/collections/courses.ts
@@ -1,0 +1,218 @@
+import type { CollectionBeforeValidateHook, CollectionConfig, Field } from "payload";
+import { checkRole } from "@repo/shared-utils";
+import type { User } from "@repo/shared-types";
+import {
+  coursesReadAccess,
+  coursesCreateAccess,
+  coursesUpdateAccess,
+  coursesDeleteAccess,
+} from "../access/courses";
+import { validateCourseDurationMode } from "../utilities/validate-course-duration-mode";
+import type { CollectionOverrides } from "../../types";
+
+const adminOnlyFieldAccess = {
+  read: ({ req: { user } }: { req: { user: unknown } }) =>
+    checkRole(["admin"], user as User | null),
+  create: ({ req: { user } }: { req: { user: unknown } }) =>
+    checkRole(["admin"], user as User | null),
+  update: ({ req: { user } }: { req: { user: unknown } }) =>
+    checkRole(["admin"], user as User | null),
+};
+
+export type CoursesOpts = {
+  eventTypesSlug?: string;
+  adminGroup?: string;
+  overrides?: CollectionOverrides;
+};
+
+const defaultAccess: NonNullable<CollectionConfig["access"]> = {
+  read: coursesReadAccess,
+  create: coursesCreateAccess,
+  update: coursesUpdateAccess,
+  delete: coursesDeleteAccess,
+};
+
+const STATUS_OPTIONS = [
+  { label: "Draft", value: "draft" },
+  { label: "Open", value: "open" },
+  { label: "Closed", value: "closed" },
+  { label: "Archived", value: "archived" },
+] as const;
+
+export function coursesCollection(opts: CoursesOpts = {}): CollectionConfig {
+  const eventTypesSlug = opts.eventTypesSlug ?? "event-types";
+  const adminGroup = opts.adminGroup ?? "Products";
+  const overrides = opts.overrides;
+
+  const defaultFields: Field[] = [
+    {
+      name: "title",
+      label: "Title",
+      type: "text",
+      required: true,
+    },
+    {
+      name: "slug",
+      label: "Slug",
+      type: "text",
+      required: true,
+      index: true,
+      admin: {
+        description: "URL slug for /courses/[slug]. Unique per tenant when multi-tenant.",
+      },
+    },
+    {
+      name: "about",
+      label: "About",
+      type: "textarea",
+      required: false,
+      admin: {
+        description: "Course description shown on the public detail page About section.",
+      },
+    },
+    {
+      name: "startDate",
+      label: "Start date",
+      type: "date",
+      required: false,
+      admin: {
+        description: "Fixed cohort start. Use with end date (not with duration).",
+        date: { pickerAppearance: "dayOnly" },
+      },
+    },
+    {
+      name: "endDate",
+      label: "End date",
+      type: "date",
+      required: false,
+      admin: {
+        description: "Fixed cohort end. Use with start date (not with duration).",
+        date: { pickerAppearance: "dayOnly" },
+      },
+    },
+    {
+      name: "durationLength",
+      label: "Duration length",
+      type: "number",
+      required: false,
+      min: 1,
+      admin: {
+        description: "Purchase-relative length (e.g. 8). Use with duration unit (not with fixed dates).",
+      },
+    },
+    {
+      name: "durationUnit",
+      label: "Duration unit",
+      type: "select",
+      required: false,
+      options: [
+        { label: "Days", value: "days" },
+        { label: "Weeks", value: "weeks" },
+      ],
+      defaultValue: "weeks",
+      admin: {
+        description: "Unit for purchase-relative duration.",
+      },
+    },
+    {
+      name: "allowedEventTypes",
+      label: "Allowed event types",
+      type: "relationship",
+      relationTo: eventTypesSlug as import("payload").CollectionSlug,
+      hasMany: true,
+      required: true,
+      admin: {
+        description: "Event types enrollees may book during their access window.",
+      },
+    },
+    {
+      name: "maxEnrollments",
+      label: "Max enrollments",
+      type: "number",
+      required: false,
+      min: 1,
+      admin: {
+        description: "Optional capacity. Leave blank for unlimited.",
+      },
+    },
+    {
+      name: "stripeProductId",
+      type: "text",
+      label: "Stripe product",
+      required: false,
+      access: adminOnlyFieldAccess,
+      admin: {
+        description: "Link to a Stripe product with a one-time default price.",
+        position: "sidebar",
+      },
+    },
+    {
+      name: "priceInformation",
+      label: "Price Information",
+      type: "group",
+      access: adminOnlyFieldAccess,
+      admin: {
+        description: "Price information. Synced from Stripe when a product is linked.",
+      },
+      fields: [
+        {
+          name: "price",
+          type: "number",
+          label: "Price (€)",
+          admin: {
+            description: "One-time price in euros (from Stripe default price)",
+          },
+        },
+      ],
+    },
+    {
+      name: "status",
+      type: "select",
+      options: [...STATUS_OPTIONS],
+      defaultValue: "draft",
+      required: true,
+      admin: {
+        description: "Open courses can be purchased; archived cannot be used for booking.",
+        position: "sidebar",
+      },
+    },
+  ];
+
+  const defaultHooks: NonNullable<CollectionConfig["hooks"]> = {
+    beforeValidate: [
+      (async ({ data }) => {
+        if (!data || typeof data !== "object") return data;
+        const result = validateCourseDurationMode(data);
+        if (result !== true) {
+          throw new Error(result);
+        }
+        return data;
+      }) satisfies CollectionBeforeValidateHook,
+    ],
+  };
+
+  const access = overrides?.access
+    ? { ...defaultAccess, ...overrides.access }
+    : defaultAccess;
+  const fields = overrides?.fields
+    ? overrides.fields({ defaultFields: [...defaultFields] })
+    : defaultFields;
+  const hooks = overrides?.hooks
+    ? overrides.hooks({ defaultHooks })
+    : defaultHooks;
+
+  return {
+    slug: "courses",
+    labels: { singular: "Course", plural: "Courses" },
+    admin: {
+      useAsTitle: "title",
+      defaultColumns: ["title", "slug", "status", "startDate", "endDate"],
+      group: adminGroup,
+      description:
+        "Courses grant enrolled users free booking of allowed event types during an access window.",
+    },
+    access,
+    fields,
+    hooks,
+  };
+}

--- a/packages/bookings-payments/src/course/collections/courses.ts
+++ b/packages/bookings-payments/src/course/collections/courses.ts
@@ -7,6 +7,7 @@ import {
   coursesUpdateAccess,
   coursesDeleteAccess,
 } from "../access/courses";
+import { resolveCourseDurationMode } from "../utilities/compute-enrollment-access-window";
 import { validateCourseDurationMode } from "../utilities/validate-course-duration-mode";
 import type { CollectionOverrides } from "../../types";
 
@@ -39,6 +40,39 @@ const STATUS_OPTIONS = [
   { label: "Archived", value: "archived" },
 ] as const;
 
+type CourseAccessWindowMode = "fixed" | "duration";
+
+function isAccessWindowMode(value: unknown): value is CourseAccessWindowMode {
+  return value === "fixed" || value === "duration";
+}
+
+/** Clear the unused mode so fixed dates and duration stay mutually exclusive. */
+function applyAccessWindowMode(
+  data: Record<string, unknown>,
+): Record<string, unknown> {
+  let mode = isAccessWindowMode(data.accessWindowMode)
+    ? data.accessWindowMode
+    : undefined;
+
+  if (!mode) {
+    const resolved = resolveCourseDurationMode(data);
+    if (resolved === "fixed" || resolved === "duration") {
+      mode = resolved;
+      data.accessWindowMode = mode;
+    }
+  }
+
+  if (mode === "fixed") {
+    data.durationLength = null;
+    data.durationUnit = null;
+  } else if (mode === "duration") {
+    data.startDate = null;
+    data.endDate = null;
+  }
+
+  return data;
+}
+
 export function coursesCollection(opts: CoursesOpts = {}): CollectionConfig {
   const eventTypesSlug = opts.eventTypesSlug ?? "event-types";
   const adminGroup = opts.adminGroup ?? "Products";
@@ -64,10 +98,35 @@ export function coursesCollection(opts: CoursesOpts = {}): CollectionConfig {
     {
       name: "about",
       label: "About",
-      type: "textarea",
+      type: "richText",
       required: false,
       admin: {
         description: "Course description shown on the public detail page About section.",
+      },
+    },
+    {
+      name: "coverImage",
+      label: "Cover image",
+      type: "upload",
+      relationTo: "media",
+      required: false,
+      admin: {
+        description: "Hero cover for the course listing and detail pages.",
+      },
+    },
+    {
+      name: "accessWindowMode",
+      label: "Access window",
+      type: "radio",
+      required: true,
+      options: [
+        { label: "Fixed start & end dates", value: "fixed" },
+        { label: "Duration from purchase", value: "duration" },
+      ],
+      admin: {
+        description:
+          "Choose one: fixed cohort dates, or access length starting from purchase.",
+        layout: "horizontal",
       },
     },
     {
@@ -76,8 +135,11 @@ export function coursesCollection(opts: CoursesOpts = {}): CollectionConfig {
       type: "date",
       required: false,
       admin: {
-        description: "Fixed cohort start. Use with end date (not with duration).",
+        description: "Fixed cohort start date.",
         date: { pickerAppearance: "dayOnly" },
+        condition: (_data, siblingData) =>
+          (siblingData as { accessWindowMode?: string })?.accessWindowMode ===
+          "fixed",
       },
     },
     {
@@ -86,8 +148,11 @@ export function coursesCollection(opts: CoursesOpts = {}): CollectionConfig {
       type: "date",
       required: false,
       admin: {
-        description: "Fixed cohort end. Use with start date (not with duration).",
+        description: "Fixed cohort end date.",
         date: { pickerAppearance: "dayOnly" },
+        condition: (_data, siblingData) =>
+          (siblingData as { accessWindowMode?: string })?.accessWindowMode ===
+          "fixed",
       },
     },
     {
@@ -97,7 +162,10 @@ export function coursesCollection(opts: CoursesOpts = {}): CollectionConfig {
       required: false,
       min: 1,
       admin: {
-        description: "Purchase-relative length (e.g. 8). Use with duration unit (not with fixed dates).",
+        description: "Access length from purchase (e.g. 8).",
+        condition: (_data, siblingData) =>
+          (siblingData as { accessWindowMode?: string })?.accessWindowMode ===
+          "duration",
       },
     },
     {
@@ -112,6 +180,9 @@ export function coursesCollection(opts: CoursesOpts = {}): CollectionConfig {
       defaultValue: "weeks",
       admin: {
         description: "Unit for purchase-relative duration.",
+        condition: (_data, siblingData) =>
+          (siblingData as { accessWindowMode?: string })?.accessWindowMode ===
+          "duration",
       },
     },
     {
@@ -180,9 +251,33 @@ export function coursesCollection(opts: CoursesOpts = {}): CollectionConfig {
 
   const defaultHooks: NonNullable<CollectionConfig["hooks"]> = {
     beforeValidate: [
-      (async ({ data }) => {
+      (async ({ data, originalDoc }) => {
         if (!data || typeof data !== "object") return data;
-        const result = validateCourseDurationMode(data);
+
+        const merged: Record<string, unknown> = {
+          ...(originalDoc && typeof originalDoc === "object"
+            ? (originalDoc as Record<string, unknown>)
+            : {}),
+          ...(data as Record<string, unknown>),
+        };
+
+        applyAccessWindowMode(merged);
+
+        const mode = isAccessWindowMode(merged.accessWindowMode)
+          ? merged.accessWindowMode
+          : undefined;
+        if (mode) {
+          ;(data as Record<string, unknown>).accessWindowMode = mode;
+          if (mode === "fixed") {
+            ;(data as Record<string, unknown>).durationLength = null;
+            ;(data as Record<string, unknown>).durationUnit = null;
+          } else {
+            ;(data as Record<string, unknown>).startDate = null;
+            ;(data as Record<string, unknown>).endDate = null;
+          }
+        }
+
+        const result = validateCourseDurationMode(merged);
         if (result !== true) {
           throw new Error(result);
         }
@@ -206,7 +301,14 @@ export function coursesCollection(opts: CoursesOpts = {}): CollectionConfig {
     labels: { singular: "Course", plural: "Courses" },
     admin: {
       useAsTitle: "title",
-      defaultColumns: ["title", "slug", "status", "startDate", "endDate"],
+      defaultColumns: [
+        "title",
+        "slug",
+        "status",
+        "accessWindowMode",
+        "startDate",
+        "endDate",
+      ],
       group: adminGroup,
       description:
         "Courses grant enrolled users free booking of allowed event types during an access window.",

--- a/packages/bookings-payments/src/course/utilities/build-course-enrollment-from-purchase.ts
+++ b/packages/bookings-payments/src/course/utilities/build-course-enrollment-from-purchase.ts
@@ -1,0 +1,41 @@
+import {
+  computeEnrollmentAccessWindow,
+  type CourseAccessWindowInput,
+} from "./compute-enrollment-access-window";
+
+export type BuildCourseEnrollmentFromPurchaseArgs = {
+  userId: number;
+  courseId: number;
+  tenantId: number;
+  purchasedAt: Date;
+  course: CourseAccessWindowInput;
+  transactionId?: string;
+};
+
+export type CourseEnrollmentCreateData = {
+  user: number;
+  course: number;
+  tenant: number;
+  status: "active";
+  purchasedAt: string;
+  accessStartsAt: string;
+  accessEndsAt: string;
+  transactionId?: string;
+};
+
+/** Build Payload create payload for a course enrollment after successful purchase. */
+export function buildCourseEnrollmentFromPurchase(
+  args: BuildCourseEnrollmentFromPurchaseArgs,
+): CourseEnrollmentCreateData {
+  const window = computeEnrollmentAccessWindow(args.course, args.purchasedAt);
+  return {
+    user: args.userId,
+    course: args.courseId,
+    tenant: args.tenantId,
+    status: "active",
+    purchasedAt: args.purchasedAt.toISOString(),
+    accessStartsAt: window.accessStartsAt,
+    accessEndsAt: window.accessEndsAt,
+    ...(args.transactionId ? { transactionId: args.transactionId } : {}),
+  };
+}

--- a/packages/bookings-payments/src/course/utilities/compute-enrollment-access-window.ts
+++ b/packages/bookings-payments/src/course/utilities/compute-enrollment-access-window.ts
@@ -1,0 +1,80 @@
+export type CourseDurationMode = "fixed" | "duration" | "invalid";
+
+export type CourseAccessWindowInput = {
+  startDate?: string | null;
+  endDate?: string | null;
+  durationLength?: number | null;
+  durationUnit?: "days" | "weeks" | null;
+};
+
+export type EnrollmentAccessWindow = {
+  accessStartsAt: string;
+  accessEndsAt: string;
+};
+
+function hasText(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function hasValidDurationLength(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 1;
+}
+
+function hasValidDurationUnit(value: unknown): value is "days" | "weeks" {
+  return value === "days" || value === "weeks";
+}
+
+/** Exactly one of fixed dates or duration length — not mixed / not neither. */
+export function resolveCourseDurationMode(
+  course: CourseAccessWindowInput,
+): CourseDurationMode {
+  const hasFixed = hasText(course.startDate) && hasText(course.endDate);
+  const hasDuration =
+    hasValidDurationLength(course.durationLength) &&
+    hasValidDurationUnit(course.durationUnit);
+
+  if (hasFixed && hasDuration) return "invalid";
+  if (hasFixed) return "fixed";
+  if (hasDuration) return "duration";
+  return "invalid";
+}
+
+function startOfUtcDay(dateOnly: string): string {
+  const day = dateOnly.trim().slice(0, 10);
+  return `${day}T00:00:00.000Z`;
+}
+
+function endOfUtcDay(dateOnly: string): string {
+  const day = dateOnly.trim().slice(0, 10);
+  return `${day}T23:59:59.999Z`;
+}
+
+/**
+ * Stamp enrollment access window from course product mode + purchase time.
+ * Fixed: product start/end (UTC day bounds). Duration: purchasedAt → +N days/weeks.
+ */
+export function computeEnrollmentAccessWindow(
+  course: CourseAccessWindowInput,
+  purchasedAt: Date,
+): EnrollmentAccessWindow {
+  const mode = resolveCourseDurationMode(course);
+  if (mode === "invalid") {
+    throw new Error("Invalid course duration mode: set fixed dates or duration, not both or neither");
+  }
+
+  if (mode === "fixed") {
+    const start = startOfUtcDay(course.startDate!);
+    const end = endOfUtcDay(course.endDate!);
+    if (Date.parse(end) < Date.parse(start)) {
+      throw new Error("Invalid course endDate: must be on or after startDate");
+    }
+    return { accessStartsAt: start, accessEndsAt: end };
+  }
+
+  const length = Math.floor(course.durationLength!);
+  const days = course.durationUnit === "weeks" ? length * 7 : length;
+  const accessStartsAt = purchasedAt.toISOString();
+  const end = new Date(purchasedAt);
+  end.setUTCDate(end.getUTCDate() + days);
+  return { accessStartsAt, accessEndsAt: end.toISOString() };
+}

--- a/packages/bookings-payments/src/course/utilities/validate-course-duration-mode.ts
+++ b/packages/bookings-payments/src/course/utilities/validate-course-duration-mode.ts
@@ -1,0 +1,35 @@
+import {
+  resolveCourseDurationMode,
+  type CourseAccessWindowInput,
+} from "./compute-enrollment-access-window";
+
+/** Payload-style validate: true or error message. */
+export function validateCourseDurationMode(
+  course: CourseAccessWindowInput,
+): true | string {
+  const mode = resolveCourseDurationMode(course);
+  if (mode === "invalid") {
+    const hasAnyDate =
+      (typeof course.startDate === "string" && course.startDate.trim()) ||
+      (typeof course.endDate === "string" && course.endDate.trim());
+    const hasAnyDuration =
+      course.durationLength != null || course.durationUnit != null;
+    if (hasAnyDate && hasAnyDuration) {
+      return "Set fixed dates or a duration, not both";
+    }
+    return "Set fixed dates (start + end) or a duration (length + unit)";
+  }
+
+  if (mode === "fixed") {
+    const start = Date.parse(`${String(course.startDate).trim().slice(0, 10)}T00:00:00.000Z`);
+    const end = Date.parse(`${String(course.endDate).trim().slice(0, 10)}T00:00:00.000Z`);
+    if (!Number.isFinite(start) || !Number.isFinite(end)) {
+      return "startDate and endDate must be valid dates";
+    }
+    if (end < start) {
+      return "endDate must be on or after startDate";
+    }
+  }
+
+  return true;
+}

--- a/packages/bookings-payments/src/index.ts
+++ b/packages/bookings-payments/src/index.ts
@@ -3,6 +3,7 @@ export type {
   BookingsPaymentsPluginConfig,
   DropInsConfig,
   ClassPassConfig,
+  CoursesConfig,
   PaymentsConfig,
   MembershipConfig,
   GetSubscriptionBookingFeeCents,
@@ -19,6 +20,21 @@ export {
   resolveDaysUntilExpiration,
   classPassExpirationDateOnly,
 } from "./class-pass/utilities/class-pass-expiration";
+export {
+  computeEnrollmentAccessWindow,
+  resolveCourseDurationMode,
+} from "./course/utilities/compute-enrollment-access-window";
+export type {
+  CourseAccessWindowInput,
+  CourseDurationMode,
+  EnrollmentAccessWindow,
+} from "./course/utilities/compute-enrollment-access-window";
+export { validateCourseDurationMode } from "./course/utilities/validate-course-duration-mode";
+export { buildCourseEnrollmentFromPurchase } from "./course/utilities/build-course-enrollment-from-purchase";
+export type {
+  BuildCourseEnrollmentFromPurchaseArgs,
+  CourseEnrollmentCreateData,
+} from "./course/utilities/build-course-enrollment-from-purchase";
 export { paymentIntentSucceeded } from "./payments/webhooks/payment-intent-succeeded";
 export type { PaymentIntentSucceededArgs } from "./payments/webhooks/payment-intent-succeeded";
 export {

--- a/packages/bookings-payments/src/index.ts
+++ b/packages/bookings-payments/src/index.ts
@@ -50,13 +50,18 @@ export {
   extendCheckoutHold,
   getActiveCheckoutHold,
   countActiveHoldQuantityForTimeslot,
+  computeCapacityBreakdownWithHolds,
   computeRemainingCapacityWithHolds,
   isHoldActive,
   isHoldWithinFulfillmentGrace,
   formatCapacityError as formatCheckoutHoldCapacityError,
 } from "./checkout-holds/service";
 export { fulfillCheckoutHold } from "./checkout-holds/fulfill";
-export type { CheckoutHoldRecord, UpsertCheckoutHoldResult } from "./checkout-holds/service";
+export type {
+  CapacityWithHoldsBreakdown,
+  CheckoutHoldRecord,
+  UpsertCheckoutHoldResult,
+} from "./checkout-holds/service";
 export type { FulfillCheckoutHoldResult } from "./checkout-holds/fulfill";
 export { bookingCheckoutHoldsCollection } from "./collections/booking-checkout-holds";
 // Payments endpoints

--- a/packages/bookings-payments/src/plugin/apply-courses.ts
+++ b/packages/bookings-payments/src/plugin/apply-courses.ts
@@ -1,0 +1,37 @@
+import { coursesCollection } from "../course/collections/courses";
+import { courseEnrollmentsCollection } from "../course/collections/course-enrollments";
+import type { CoursesConfig } from "../types";
+import type { PluginContext } from "./context";
+import { injectAllowedCoursesIntoCollection } from "./inject-payment-methods";
+
+/**
+ * Applies the courses feature: courses + course-enrollments collections
+ * and allowedCourses injection into event-types.
+ */
+export function applyCoursesFeature(
+  ctx: PluginContext,
+  courses: CoursesConfig,
+): void {
+  const eventTypesSlug = courses.eventTypesSlug ?? "event-types";
+  const coursesAdminGroup = courses.adminGroup ?? "Products";
+  const enrollmentsAdminGroup = courses.adminGroup ?? "Billing";
+
+  ctx.collections.push(
+    coursesCollection({
+      eventTypesSlug,
+      adminGroup: coursesAdminGroup,
+      overrides: courses.coursesOverrides,
+    }),
+  );
+  ctx.collections.push(
+    courseEnrollmentsCollection({
+      adminGroup: enrollmentsAdminGroup,
+      overrides: courses.courseEnrollmentsOverrides,
+    }),
+  );
+
+  const target = ctx.collections.find((c) => c.slug === eventTypesSlug);
+  if (target) {
+    injectAllowedCoursesIntoCollection(target, eventTypesSlug);
+  }
+}

--- a/packages/bookings-payments/src/plugin/index.ts
+++ b/packages/bookings-payments/src/plugin/index.ts
@@ -5,6 +5,7 @@ import type { BookingsPaymentsPluginConfig } from "../types";
 import type { PluginContext } from "./context";
 import { applyDropInsFeature } from "./apply-drop-ins";
 import { applyClassPassFeature } from "./apply-class-pass";
+import { applyCoursesFeature } from "./apply-courses";
 import { applyPaymentsFeature } from "./apply-payments";
 import { applyMembershipFeature } from "./apply-membership";
 import { injectTransactionsIntoBookings } from "./inject-transactions";
@@ -53,8 +54,13 @@ export const bookingsPaymentsPlugin =
       enabled: true,
       paymentMethodSlugs: [],
     });
+    const courses = normalizeFeatureOption(pluginOptions.courses, {
+      enabled: true,
+      eventTypesSlug: "event-types",
+    });
 
-    const anyEnabled = dropIns?.enabled || classPass?.enabled || membership?.enabled;
+    const anyEnabled =
+      dropIns?.enabled || classPass?.enabled || membership?.enabled || courses?.enabled;
     if (!anyEnabled) {
       return config;
     }
@@ -87,12 +93,17 @@ export const bookingsPaymentsPlugin =
       applyClassPassFeature(ctx, classPass);
     }
 
+    // Courses feature: courses, course-enrollments, allowedCourses injection
+    if (courses?.enabled) {
+      applyCoursesFeature(ctx, courses);
+    }
+
     // Membership feature: memberships, subscriptions, users, endpoints, allowedPlans injection
     if (membership?.enabled) {
       applyMembershipFeature(ctx, membership);
     }
 
-    // Transactions at root: one collection for subscription, class-pass, or drop-in booking payments
+    // Transactions at root: one collection for subscription, class-pass, course, or drop-in booking payments
     const needsTransactions =
       !ctx.collections.some((c) => c.slug === "transactions");
     if (needsTransactions) {

--- a/packages/bookings-payments/src/plugin/inject-payment-methods.ts
+++ b/packages/bookings-payments/src/plugin/inject-payment-methods.ts
@@ -94,3 +94,23 @@ export function injectAllowedDropInIntoCollection(
     },
   });
 }
+
+/**
+ * Injects or appends "allowedCourses" into the paymentMethods group of the given collection.
+ * Used when the courses feature is enabled.
+ */
+export function injectAllowedCoursesIntoCollection(
+  collection: CollectionConfig,
+  _slug: string
+): void {
+  injectPaymentMethodField(collection, "allowedCourses", {
+    type: "relationship",
+    label: "Allowed Courses",
+    relationTo: "courses" as CollectionSlug,
+    hasMany: true,
+    admin: {
+      description:
+        "Courses that grant free booking of this event type during the enrollee's access window.",
+    },
+  });
+}

--- a/packages/bookings-payments/src/types.ts
+++ b/packages/bookings-payments/src/types.ts
@@ -129,6 +129,20 @@ export type MembershipConfig = {
 export type FeatureOption<T> = true | T;
 
 /**
+ * Courses feature config. When enabled, adds courses + course-enrollments collections
+ * and allowedCourses injection into event-types.
+ */
+export type CoursesConfig = {
+  enabled: boolean;
+  eventTypesSlug?: string;
+  adminGroup?: string;
+  /** Override access/fields/hooks for courses (e.g. tenant-scoped in multi-tenant apps). */
+  coursesOverrides?: CollectionOverrides;
+  /** Override access/fields/hooks for course-enrollments. */
+  courseEnrollmentsOverrides?: CollectionOverrides;
+};
+
+/**
  * Unified bookings-payments plugin config. Each feature accepts the same shape:
  * `true` (enable with defaults) or a config object.
  */
@@ -139,6 +153,8 @@ export type BookingsPaymentsPluginConfig = {
   classPass?: FeatureOption<ClassPassConfig>;
   /** Membership (subscriptions): `true` or `{ ...MembershipConfig }` */
   membership?: FeatureOption<MembershipConfig>;
+  /** Courses: `true` or `{ ...CoursesConfig }` */
+  courses?: FeatureOption<CoursesConfig>;
 };
 
 export type ClassPassLike = {
@@ -155,6 +171,8 @@ export type EventTypeLike = {
   paymentMethods?: {
     /** Relationship to class-pass-types (array of IDs or objects). Which pass types are accepted. */
     allowedClassPasses?: unknown[] | null;
+    /** Relationship to courses (array of IDs or objects). */
+    allowedCourses?: unknown[] | null;
     paymentsEnabled?: boolean;
   };
 };

--- a/packages/bookings/bookings-next/__tests__/components/payment-methods-discount.test.tsx
+++ b/packages/bookings/bookings-next/__tests__/components/payment-methods-discount.test.tsx
@@ -28,6 +28,9 @@ vi.mock('@repo/trpc/client', () => ({
       },
     },
     bookings: {
+      getValidCourseEnrollmentsForTimeslot: {
+        queryOptions: () => ({ queryKey: ['bookings.getValidCourseEnrollmentsForTimeslot'] }),
+      },
       getValidClassPassesForTimeslot: {
         queryOptions: () => ({ queryKey: ['bookings.getValidClassPassesForTimeslot'] }),
       },
@@ -99,6 +102,8 @@ describe('PaymentMethods discount forwarding', () => {
             },
             isLoading: false,
           }
+        case 'bookings.getValidCourseEnrollmentsForTimeslot':
+          return { data: [], isLoading: false, isFetching: false }
         case 'bookings.getValidClassPassesForTimeslot':
           return { data: [], isLoading: false }
         case 'bookings.getPurchasableClassPassTypesForTimeslot':
@@ -321,6 +326,8 @@ describe('PaymentMethods discount forwarding', () => {
             },
             isLoading: false,
           }
+        case 'bookings.getValidCourseEnrollmentsForTimeslot':
+          return { data: [], isLoading: false, isFetching: false }
         case 'bookings.getValidClassPassesForTimeslot':
           return { data: [], isLoading: false }
         case 'bookings.getPurchasableClassPassTypesForTimeslot':

--- a/packages/bookings/bookings-next/__tests__/components/payment-methods-dropin-with-membership.test.tsx
+++ b/packages/bookings/bookings-next/__tests__/components/payment-methods-dropin-with-membership.test.tsx
@@ -22,6 +22,9 @@ vi.mock('@repo/trpc/client', () => ({
       },
     },
     bookings: {
+      getValidCourseEnrollmentsForTimeslot: {
+        queryOptions: () => ({ queryKey: ['bookings.getValidCourseEnrollmentsForTimeslot'] }),
+      },
       getValidClassPassesForTimeslot: {
         queryOptions: () => ({ queryKey: ['bookings.getValidClassPassesForTimeslot'] }),
       },
@@ -125,6 +128,8 @@ function setupQuery(subscriptionData: ReturnType<typeof makeSubscriptionQuery>) 
     switch (key) {
       case 'subscriptions.getSubscriptionForTimeslot':
         return subscriptionData
+      case 'bookings.getValidCourseEnrollmentsForTimeslot':
+        return { data: [], isLoading: false, isFetching: false }
       case 'bookings.getValidClassPassesForTimeslot':
         return { data: [], isLoading: false }
       case 'bookings.getPurchasableClassPassTypesForTimeslot':

--- a/packages/bookings/bookings-next/src/components/bookings/booking-page-client-smart.tsx
+++ b/packages/bookings/bookings-next/src/components/bookings/booking-page-client-smart.tsx
@@ -20,6 +20,7 @@ type PaymentMethodsLike = {
       }>
     | null
   allowedClassPasses?: Array<{ maxBookingsPerTimeslot?: number | null }> | null
+  allowedCourses?: unknown[] | null
 } | null
 
 function isObject(value: unknown): value is Record<string, unknown> {
@@ -263,14 +264,15 @@ export const BookingPageClientSmart: React.FC<BookingPageClientSmartProps> = ({
     useCheckoutHolds,
   ])
 
-  // Gate for showing "Payment Methods" block (Drop-in / Membership / Class pass tabs). Only the timeslot data from the server
+  // Gate for showing "Payment Methods" block (Drop-in / Membership / Class pass / Course tabs). Only the timeslot data from the server
   // is used; there is no client-side Stripe Connect or tenant check. If the server returns a timeslot without
   // eventType.paymentMethods populated (e.g. no tenant context so depth/overrideAccess omit it), this is false.
   const paymentMethods = asPaymentMethodsLike(timeslot.eventType?.paymentMethods)
   const hasPaymentMethods = Boolean(
     paymentMethods?.allowedDropIn ||
     (paymentMethods?.allowedPlans?.length ?? 0) > 0 ||
-    (paymentMethods?.allowedClassPasses?.length ?? 0) > 0
+    (paymentMethods?.allowedClassPasses?.length ?? 0) > 0 ||
+    (paymentMethods?.allowedCourses?.length ?? 0) > 0
   )
 
   const capacityMaxQuantity = Math.max(1, timeslot.remainingCapacity || 1)
@@ -316,7 +318,11 @@ export const BookingPageClientSmart: React.FC<BookingPageClientSmartProps> = ({
         return maxFromMaybeCap(rawMax)
       }) ?? []
 
-    const caps = [dropInMax, ...planCapsWithLegacy, ...classPassCaps]
+    // Courses have no per-timeslot credit cap in v1 — treat as unlimited for quantity UI.
+    const courseCap =
+      (paymentMethods?.allowedCourses?.length ?? 0) > 0 ? Infinity : 1
+
+    const caps = [dropInMax, ...planCapsWithLegacy, ...classPassCaps, courseCap]
     return caps.some((c) => c === Infinity) ? Infinity : Math.max(1, ...caps)
   })()
 

--- a/packages/bookings/bookings-plugin/__tests__/booking.test.ts
+++ b/packages/bookings/bookings-plugin/__tests__/booking.test.ts
@@ -23,6 +23,8 @@ import { setDbString } from "@repo/payload-testing/src/utils/payload-config";
 
 import { User } from "@repo/shared-types";
 
+import { futureTimeslotWindow } from "./timeslot-fixtures";
+
 let payload: Payload;
 let restClient: NextRESTClient;
 let user: User;
@@ -89,9 +91,7 @@ describe("Booking tests", () => {
       const lesson = await payload.create({
         collection: "timeslots",
         data: {
-          date: new Date(),
-          startTime: new Date(Date.now() + 2 * 60 * 60 * 1000),
-          endTime: new Date(Date.now() + 3 * 60 * 60 * 1000),
+          ...futureTimeslotWindow(),
           eventType: classOptionWithoutPaymentMethods.id,
           location: "Test Location",
         },
@@ -151,9 +151,7 @@ describe("Booking tests", () => {
       const lesson = await payload.create({
         collection: "timeslots",
         data: {
-          date: new Date(),
-          startTime: new Date(Date.now() + 2 * 60 * 60 * 1000),
-          endTime: new Date(Date.now() + 3 * 60 * 60 * 1000),
+          ...futureTimeslotWindow(),
           eventType: classOption.id,
           location: "Test Location",
         },
@@ -213,9 +211,7 @@ describe("Booking tests", () => {
       const lesson = await payload.create({
         collection: "timeslots",
         data: {
-          date: new Date(),
-          startTime: new Date(Date.now() + 2 * 60 * 60 * 1000),
-          endTime: new Date(Date.now() + 3 * 60 * 60 * 1000),
+          ...futureTimeslotWindow(),
           eventType: classOption.id,
           location: "Test Location",
         },
@@ -287,9 +283,7 @@ describe("Booking tests", () => {
       const lesson = await payload.create({
         collection: "timeslots",
         data: {
-          date: new Date(),
-          startTime: new Date(Date.now() + 2 * 60 * 60 * 1000),
-          endTime: new Date(Date.now() + 3 * 60 * 60 * 1000),
+          ...futureTimeslotWindow(),
           eventType: classOption.id,
           location: "Test Location",
         },
@@ -330,9 +324,7 @@ describe("Booking tests", () => {
       const lesson = await payload.create({
         collection: "timeslots",
         data: {
-          date: new Date(),
-          startTime: new Date(Date.now() + 2 * 60 * 60 * 1000),
-          endTime: new Date(Date.now() + 3 * 60 * 60 * 1000),
+          ...futureTimeslotWindow(),
           eventType: classOption.id,
           location: "Test Location",
         },

--- a/packages/bookings/bookings-plugin/__tests__/hooks.test.ts
+++ b/packages/bookings/bookings-plugin/__tests__/hooks.test.ts
@@ -19,6 +19,8 @@ import { EventType, Timeslot, User, Booking } from "@repo/shared-types";
 
 import { NextRESTClient } from "@repo/payload-testing/src/helpers/NextRESTClient";
 
+import { futureTimeslotWindow } from "./timeslot-fixtures";
+
 const TEST_TIMEOUT = 60000; // 60 seconds
 const HOOK_TIMEOUT = 300000; // 5 minutes for setup hooks (DB + Payload init can be slow under turbo parallelism)
 
@@ -72,9 +74,7 @@ describe("Hook tests", () => {
         const lesson = await payload.create({
           collection: "timeslots",
           data: {
-            date: new Date(),
-            startTime: new Date(Date.now() + 2 * 60 * 60 * 1000),
-            endTime: new Date(Date.now() + 3 * 60 * 60 * 1000),
+            ...futureTimeslotWindow(),
             eventType: eventType.id,
             location: "Test Location",
             lockOutTime: 30,
@@ -127,9 +127,7 @@ describe("Hook tests", () => {
         const lesson = await payload.create({
           collection: "timeslots",
           data: {
-            date: new Date(),
-            startTime: new Date(Date.now() + 2 * 60 * 60 * 1000),
-            endTime: new Date(Date.now() + 3 * 60 * 60 * 1000),
+            ...futureTimeslotWindow(),
             eventType: eventType.id,
             location: "Test Location",
             lockOutTime: 30,
@@ -155,9 +153,7 @@ describe("Hook tests", () => {
         const lesson = (await payload.create({
           collection: "timeslots",
           data: {
-            date: new Date(Date.now() + 24 * 60 * 60 * 1000), // Tomorrow
-            startTime: new Date(Date.now() + 25 * 60 * 60 * 1000),
-            endTime: new Date(Date.now() + 26 * 60 * 60 * 1000),
+            ...futureTimeslotWindow({ daysFromNow: 1, startHour: 10 }),
             eventType: eventType.id,
             location: "Test Location",
             lockOutTime: 30,
@@ -196,9 +192,7 @@ describe("Hook tests", () => {
         const lesson = await payload.create({
           collection: "timeslots",
           data: {
-            date: new Date(Date.now() + 24 * 60 * 60 * 1000), // Tomorrow
-            startTime: new Date(Date.now() + 25 * 60 * 60 * 1000),
-            endTime: new Date(Date.now() + 26 * 60 * 60 * 1000),
+            ...futureTimeslotWindow({ daysFromNow: 1, startHour: 10 }),
             eventType: eventType.id,
             location: "Test Location",
             lockOutTime: 30,
@@ -223,9 +217,7 @@ describe("Hook tests", () => {
         const lesson = await payload.create({
           collection: "timeslots",
           data: {
-            date: new Date(Date.now() + 24 * 60 * 60 * 1000),
-            startTime: new Date(Date.now() + 25 * 60 * 60 * 1000),
-            endTime: new Date(Date.now() + 26 * 60 * 60 * 1000),
+            ...futureTimeslotWindow({ daysFromNow: 1, startHour: 10 }),
             eventType: eventType.id,
             location: "Test Location",
             lockOutTime: 30,
@@ -266,9 +258,7 @@ describe("Hook tests", () => {
         const lesson = await payload.create({
           collection: "timeslots",
           data: {
-            date: new Date(Date.now() + 24 * 60 * 60 * 1000),
-            startTime: new Date(Date.now() + 25 * 60 * 60 * 1000),
-            endTime: new Date(Date.now() + 26 * 60 * 60 * 1000),
+            ...futureTimeslotWindow({ daysFromNow: 1, startHour: 10 }),
             eventType: eventType.id,
             location: "Test Location",
             lockOutTime: 30,
@@ -313,13 +303,13 @@ describe("Hook tests", () => {
         const lesson = await payload.create({
           collection: "timeslots",
           data: {
-            date: new Date(),
-            startTime: new Date(Date.now() + 10 * 60 * 1000), // 10 minutes from now
-            endTime: new Date(Date.now() + 70 * 60 * 1000),
+            // Midday tomorrow with a lockout window that already covers "now"
+            // (relative Date.now()+10m breaks after local midnight recombination).
+            ...futureTimeslotWindow({ daysFromNow: 1, startHour: 10 }),
             eventType: eventType.id,
             location: "Test Location",
-            lockOutTime: 30, // 30 minutes lockout
-            originalLockOutTime: 30,
+            lockOutTime: 60 * 48,
+            originalLockOutTime: 60 * 48,
           },
         });
 
@@ -329,7 +319,7 @@ describe("Hook tests", () => {
           id: lesson.id,
         });
 
-        // Should be closed because startTime - 30 minutes is in the past
+        // Should be closed because lockout deadline is before now
         expect((readTimeslot as Timeslot).bookingStatus).toBe("closed");
       },
       TEST_TIMEOUT
@@ -343,9 +333,7 @@ describe("Hook tests", () => {
         const lesson = await payload.create({
           collection: "timeslots",
           data: {
-            date: new Date(),
-            startTime: new Date(Date.now() + 2 * 60 * 60 * 1000),
-            endTime: new Date(Date.now() + 3 * 60 * 60 * 1000),
+            ...futureTimeslotWindow(),
             eventType: eventType.id,
             location: "Test Location",
             lockOutTime: 30,
@@ -375,9 +363,7 @@ describe("Hook tests", () => {
         const lesson = await payload.create({
           collection: "timeslots",
           data: {
-            date: new Date(),
-            startTime: new Date(Date.now() + 2 * 60 * 60 * 1000),
-            endTime: new Date(Date.now() + 3 * 60 * 60 * 1000),
+            ...futureTimeslotWindow(),
             eventType: eventType.id,
             location: "Test Location",
             lockOutTime: 30,
@@ -416,9 +402,7 @@ describe("Hook tests", () => {
         const lesson = await payload.create({
           collection: "timeslots",
           data: {
-            date: new Date(),
-            startTime: new Date(Date.now() + 2 * 60 * 60 * 1000),
-            endTime: new Date(Date.now() + 3 * 60 * 60 * 1000),
+            ...futureTimeslotWindow(),
             eventType: eventType.id,
             location: "Test Location",
             lockOutTime: 45,
@@ -464,9 +448,7 @@ describe("Hook tests", () => {
         const lesson = await payload.create({
           collection: "timeslots",
           data: {
-            date: new Date(),
-            startTime: new Date(Date.now() + 2 * 60 * 60 * 1000),
-            endTime: new Date(Date.now() + 3 * 60 * 60 * 1000),
+            ...futureTimeslotWindow(),
             eventType: eventType.id,
             location: "Test Location",
             lockOutTime: 0, // Initially 0 because we'll create a booking
@@ -513,9 +495,7 @@ describe("Hook tests", () => {
         const lesson = await payload.create({
           collection: "timeslots",
           data: {
-            date: new Date(),
-            startTime: new Date(Date.now() + 2 * 60 * 60 * 1000),
-            endTime: new Date(Date.now() + 3 * 60 * 60 * 1000),
+            ...futureTimeslotWindow(),
             eventType: eventType.id,
             location: "Test Location",
             lockOutTime: 45,
@@ -569,9 +549,7 @@ describe("Hook tests", () => {
         const lesson = await payload.create({
           collection: "timeslots",
           data: {
-            date: new Date(),
-            startTime: new Date(Date.now() + 2 * 60 * 60 * 1000),
-            endTime: new Date(Date.now() + 3 * 60 * 60 * 1000),
+            ...futureTimeslotWindow(),
             eventType: eventType.id,
             location: "Test Location",
             lockOutTime: 45,
@@ -624,9 +602,7 @@ describe("Hook tests", () => {
         const lesson = await payload.create({
           collection: "timeslots",
           data: {
-            date: new Date(),
-            startTime: new Date(Date.now() + 2 * 60 * 60 * 1000),
-            endTime: new Date(Date.now() + 3 * 60 * 60 * 1000),
+            ...futureTimeslotWindow(),
             eventType: eventType.id,
             location: "Test Location",
             lockOutTime: 30,
@@ -674,9 +650,7 @@ describe("Hook tests", () => {
         const lesson = await payload.create({
           collection: "timeslots",
           data: {
-            date: new Date(),
-            startTime: new Date(Date.now() + 2 * 60 * 60 * 1000),
-            endTime: new Date(Date.now() + 3 * 60 * 60 * 1000),
+            ...futureTimeslotWindow(),
             eventType: eventType.id,
             location: "Test Location",
             lockOutTime: 30,
@@ -739,9 +713,7 @@ describe("Hook tests", () => {
         const lesson = await payload.create({
           collection: "timeslots",
           data: {
-            date: new Date(),
-            startTime: new Date(Date.now() + 2 * 60 * 60 * 1000),
-            endTime: new Date(Date.now() + 3 * 60 * 60 * 1000),
+            ...futureTimeslotWindow(),
             eventType: eventType.id,
             location: "Test Location",
             lockOutTime: 30,

--- a/packages/bookings/bookings-plugin/__tests__/lesson.test.ts
+++ b/packages/bookings/bookings-plugin/__tests__/lesson.test.ts
@@ -21,7 +21,10 @@ import { NextRESTClient } from "@repo/payload-testing/src/helpers/NextRESTClient
 
 import { EventType, Timeslot } from "@repo/shared-types";
 
-import { futureTimeslotWindow, pastTimeslotWindow } from "./timeslot-fixtures";
+import {
+  earlierTodayTimeslotWindow,
+  futureTimeslotWindow,
+} from "./timeslot-fixtures";
 
 const TEST_TIMEOUT = 30000; // 30 seconds
 const HOOK_TIMEOUT = 300000; // 5 minutes for setup hooks (DB + Payload init can be slow under turbo parallelism)
@@ -265,7 +268,9 @@ describe("Timeslot tests", () => {
       const lesson = await payload.create({
         collection: "timeslots",
         data: {
-          ...pastTimeslotWindow(),
+          // Must be earlier today (not yesterday): anonymous REST read access
+          // filters startTime > startOfToday, so past calendar days 404.
+          ...earlierTodayTimeslotWindow(),
           eventType: eventType.id,
           location: "Test Location",
         },

--- a/packages/bookings/bookings-plugin/__tests__/lesson.test.ts
+++ b/packages/bookings/bookings-plugin/__tests__/lesson.test.ts
@@ -21,6 +21,8 @@ import { NextRESTClient } from "@repo/payload-testing/src/helpers/NextRESTClient
 
 import { EventType, Timeslot } from "@repo/shared-types";
 
+import { futureTimeslotWindow, pastTimeslotWindow } from "./timeslot-fixtures";
+
 const TEST_TIMEOUT = 30000; // 30 seconds
 const HOOK_TIMEOUT = 300000; // 5 minutes for setup hooks (DB + Payload init can be slow under turbo parallelism)
 
@@ -238,19 +240,10 @@ describe("Timeslot tests", () => {
   it(
     "should have a booking status of active",
     async () => {
-      const now = new Date(); // Get the current date and time
-      const tomorrow = new Date(now); // Create a new Date object based on the current date
-      tomorrow.setDate(now.getDate() + 1);
-
-      const oneHourLater = new Date(tomorrow); // Create a copy of the current date
-      oneHourLater.setHours(oneHourLater.getHours() + 1);
-
       const lesson = await payload.create({
         collection: "timeslots",
         data: {
-          date: tomorrow,
-          startTime: tomorrow,
-          endTime: oneHourLater,
+          ...futureTimeslotWindow({ daysFromNow: 1, startHour: 10 }),
           lockOutTime: 720,
           eventType: eventType.id,
           location: "Test Location",
@@ -272,9 +265,7 @@ describe("Timeslot tests", () => {
       const lesson = await payload.create({
         collection: "timeslots",
         data: {
-          date: new Date(),
-          startTime: new Date(Date.now() - 2 * 60 * 60 * 1000),
-          endTime: new Date(Date.now() - 1 * 60 * 60 * 1000),
+          ...pastTimeslotWindow(),
           eventType: eventType.id,
           location: "Test Location",
         },
@@ -302,9 +293,7 @@ describe("Timeslot tests", () => {
       const lesson = await payload.create({
         collection: "timeslots",
         data: {
-          date: new Date(),
-          startTime: new Date(Date.now() + 2 * 60 * 60 * 1000),
-          endTime: new Date(Date.now() + 3 * 60 * 60 * 1000),
+          ...futureTimeslotWindow(),
           eventType: eventType.id,
           location: "Test Location",
         },
@@ -369,9 +358,7 @@ describe("Timeslot tests", () => {
       const lesson = await payload.create({
         collection: "timeslots",
         data: {
-          date: new Date(),
-          startTime: new Date(Date.now() + 2 * 60 * 60 * 1000),
-          endTime: new Date(Date.now() + 3 * 60 * 60 * 1000),
+          ...futureTimeslotWindow(),
           eventType: eventType.id,
           location: "Test Location",
         },

--- a/packages/bookings/bookings-plugin/__tests__/timeslot-fixtures.ts
+++ b/packages/bookings/bookings-plugin/__tests__/timeslot-fixtures.ts
@@ -72,7 +72,7 @@ export function futureTimeslotWindow(options?: {
   return windowOnDay(zonedDay(daysFromNow), startHour, durationHours);
 }
 
-/** Past midday slot for closed-status assertions. */
+/** Past midday slot for closed-status assertions (Local API / admin). */
 export function pastTimeslotWindow(options?: {
   daysAgo?: number;
   startHour?: number;
@@ -82,4 +82,49 @@ export function pastTimeslotWindow(options?: {
   const startHour = options?.startHour ?? 10;
   const durationHours = options?.durationHours ?? 1;
   return windowOnDay(zonedDay(-daysAgo), startHour, durationHours);
+}
+
+/**
+ * Past slot that still falls after UTC midnight today.
+ *
+ * Anonymous timeslot read access filters `startTime > startOfToday` (tests set TZ=UTC),
+ * so yesterday's `pastTimeslotWindow()` 404s via REST. Prefer ~2h ago, clamped to 00:01 UTC.
+ */
+export function earlierTodayTimeslotWindow(options?: {
+  durationHours?: number;
+}): TimeslotWindow {
+  const durationHours = options?.durationHours ?? 1;
+  const nowMs = Date.now();
+  const startOfTodayUtc = new Date(nowMs);
+  startOfTodayUtc.setUTCHours(0, 0, 0, 0);
+
+  const minStartMs = startOfTodayUtc.getTime() + 60_000;
+  const preferredStartMs = nowMs - 2 * 60 * 60 * 1000;
+  const startMs = Math.max(minStartMs, preferredStartMs);
+
+  if (startMs >= nowMs) {
+    throw new Error(
+      "earlierTodayTimeslotWindow requires the clock to be at least ~1 minute into the UTC day",
+    );
+  }
+
+  const start = new Date(startMs);
+  const end = new Date(startMs + durationHours * 60 * 60 * 1000);
+  const startDublin = new TZDate(start, TEST_TIMESLOT_TIMEZONE);
+  const day = new TZDate(
+    startDublin.getFullYear(),
+    startDublin.getMonth(),
+    startDublin.getDate(),
+    0,
+    0,
+    0,
+    0,
+    TEST_TIMESLOT_TIMEZONE,
+  );
+
+  return {
+    date: new Date(day.getTime()),
+    startTime: start,
+    endTime: end,
+  };
 }

--- a/packages/bookings/bookings-plugin/__tests__/timeslot-fixtures.ts
+++ b/packages/bookings/bookings-plugin/__tests__/timeslot-fixtures.ts
@@ -1,0 +1,85 @@
+import { TZDate } from "@date-fns/tz";
+
+/**
+ * Plugin default timezone. Timeslot hooks recombine start/end wall-clock times onto
+ * `date` in this zone — relative `Date.now() + N hours` fixtures break after local
+ * midnight (CI often runs late UTC).
+ */
+export const TEST_TIMESLOT_TIMEZONE = "Europe/Dublin";
+
+type TimeslotWindow = {
+  date: Date;
+  startTime: Date;
+  endTime: Date;
+};
+
+const zonedDay = (daysFromToday: number) => {
+  const now = new TZDate(new Date(), TEST_TIMESLOT_TIMEZONE);
+  return new TZDate(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate() + daysFromToday,
+    0,
+    0,
+    0,
+    0,
+    TEST_TIMESLOT_TIMEZONE,
+  );
+};
+
+const windowOnDay = (
+  day: TZDate,
+  startHour: number,
+  durationHours: number,
+): TimeslotWindow => {
+  const start = new TZDate(
+    day.getFullYear(),
+    day.getMonth(),
+    day.getDate(),
+    startHour,
+    0,
+    0,
+    0,
+    TEST_TIMESLOT_TIMEZONE,
+  );
+  const end = new TZDate(
+    day.getFullYear(),
+    day.getMonth(),
+    day.getDate(),
+    startHour + durationHours,
+    0,
+    0,
+    0,
+    TEST_TIMESLOT_TIMEZONE,
+  );
+
+  return {
+    date: new Date(day.getTime()),
+    startTime: new Date(start.getTime()),
+    endTime: new Date(end.getTime()),
+  };
+};
+
+/** Future midday slot that stays on the same calendar day after timezone recombination. */
+export function futureTimeslotWindow(options?: {
+  daysFromNow?: number;
+  startHour?: number;
+  durationHours?: number;
+}): TimeslotWindow {
+  const daysFromNow = options?.daysFromNow ?? 1;
+  const startHour = options?.startHour ?? 10;
+  const durationHours = options?.durationHours ?? 1;
+  return windowOnDay(zonedDay(daysFromNow), startHour, durationHours);
+}
+
+/** Past midday slot for closed-status assertions. */
+export function pastTimeslotWindow(options?: {
+  daysAgo?: number;
+  startHour?: number;
+  durationHours?: number;
+}): TimeslotWindow {
+  const daysAgo = options?.daysAgo ?? 1;
+  const startHour = options?.startHour ?? 10;
+  const durationHours = options?.durationHours ?? 1;
+  return windowOnDay(zonedDay(-daysAgo), startHour, durationHours);
+}

--- a/packages/bookings/bookings-plugin/__tests__/timeslot-fixtures.unit.test.ts
+++ b/packages/bookings/bookings-plugin/__tests__/timeslot-fixtures.unit.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { futureTimeslotWindow, pastTimeslotWindow } from "./timeslot-fixtures";
+import {
+  earlierTodayTimeslotWindow,
+  futureTimeslotWindow,
+  pastTimeslotWindow,
+} from "./timeslot-fixtures";
 
 describe("timeslot fixtures", () => {
   beforeEach(() => {
@@ -28,5 +32,17 @@ describe("timeslot fixtures", () => {
 
     expect(window.endTime.getTime()).toBeLessThan(now);
     expect(window.startTime.getTime()).toBeLessThan(window.endTime.getTime());
+  });
+
+  it("keeps earlier-today windows readable under UTC startOfToday access", () => {
+    const now = Date.now();
+    const startOfTodayUtc = new Date(now);
+    startOfTodayUtc.setUTCHours(0, 0, 0, 0);
+
+    const window = earlierTodayTimeslotWindow();
+
+    expect(window.startTime.getTime()).toBeGreaterThan(startOfTodayUtc.getTime());
+    expect(window.startTime.getTime()).toBeLessThan(now);
+    expect(window.endTime.getTime()).toBeGreaterThan(window.startTime.getTime());
   });
 });

--- a/packages/bookings/bookings-plugin/__tests__/timeslot-fixtures.unit.test.ts
+++ b/packages/bookings/bookings-plugin/__tests__/timeslot-fixtures.unit.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { futureTimeslotWindow, pastTimeslotWindow } from "./timeslot-fixtures";
+
+describe("timeslot fixtures", () => {
+  beforeEach(() => {
+    // Late UTC evening — the old Date.now()+2h pattern recombines onto today in
+    // Europe/Dublin and lands in the past.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-29T21:36:25.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("keeps future windows after local midnight", () => {
+    const now = Date.now();
+    const window = futureTimeslotWindow();
+
+    expect(window.startTime.getTime()).toBeGreaterThan(now);
+    expect(window.endTime.getTime()).toBeGreaterThan(window.startTime.getTime());
+  });
+
+  it("keeps past windows before now", () => {
+    const now = Date.now();
+    const window = pastTimeslotWindow();
+
+    expect(window.endTime.getTime()).toBeLessThan(now);
+    expect(window.startTime.getTime()).toBeLessThan(window.endTime.getTime());
+  });
+});

--- a/packages/bookings/bookings-plugin/src/collections/timeslots.ts
+++ b/packages/bookings/bookings-plugin/src/collections/timeslots.ts
@@ -499,6 +499,10 @@ const defaultAccess: AccessControls = {
 
 const defaultAdmin: CollectionAdminOptions = {
   group: "Bookings",
+  // Prevent timeslots from appearing as internal link/relationship targets in Lexical
+  // (they are first in many apps' collection order and enableRichTextLink defaults to true).
+  enableRichTextLink: false,
+  enableRichTextRelationship: false,
   components: {
     views: {
       list: {
@@ -728,7 +732,8 @@ export const generateTimeslotCollection = (
         : defaultAccess),
     },
     admin: {
-      ...(overrides?.admin || defaultAdmin),
+      ...defaultAdmin,
+      ...(overrides?.admin ?? {}),
     },
     hooks: {
       ...(overrides?.hooks && typeof overrides?.hooks === "function"

--- a/packages/payments/payments-next/src/components/checkout-form.tsx
+++ b/packages/payments/payments-next/src/components/checkout-form.tsx
@@ -57,7 +57,11 @@ function PaymentForm({
 }: {
   priceComponent: React.ReactNode;
   price: number;
-  onPaymentRedirectStart?: () => void;
+  /**
+   * Called once validation succeeds and Stripe confirm is about to run.
+   * May return an abort fn invoked if confirm fails without leaving the page.
+   */
+  onPaymentRedirectStart?: () => void | (() => void);
   /** URL Stripe redirects to after payment. Defaults to /dashboard for backwards compatibility. */
   returnUrl?: string;
 }) {
@@ -81,7 +85,6 @@ function PaymentForm({
 
     setIsLoading(true);
     setMessage(null);
-    onPaymentRedirectStart?.();
     trackEvent("Payment Button Clicked", {
       revenue: { amount: Number(price.toFixed(2)), currency: "EUR" },
     });
@@ -95,11 +98,18 @@ function PaymentForm({
       ? baseReturn
       : `${origin}${baseReturn.startsWith("/") ? baseReturn : `/${baseReturn}`}`;
 
+    let abortPaymentRedirect: (() => void) | undefined;
+
     try {
       const { error: submitError } = await elements.submit();
       if (submitError) {
         setMessage(submitError.message || "An unexpected error occurred.");
         return;
+      }
+
+      const maybeAbort = onPaymentRedirectStart?.();
+      if (typeof maybeAbort === "function") {
+        abortPaymentRedirect = maybeAbort;
       }
 
       const { error } = await stripe.confirmPayment({
@@ -114,15 +124,17 @@ function PaymentForm({
       // your `return_url`. For some payment methods like iDEAL, your customer will
       // be redirected to an intermediate site first to authorize the payment, then
       // redirected to the `return_url`.
-      if (
-        error &&
-        (error.type === "card_error" || error.type === "validation_error")
-      ) {
-        setMessage(error.message || "An unexpected error occurred.");
-      } else if (error) {
-        setMessage("An unexpected error occurred.");
+      if (error) {
+        abortPaymentRedirect?.();
+        abortPaymentRedirect = undefined;
+        if (error.type === "card_error" || error.type === "validation_error") {
+          setMessage(error.message || "An unexpected error occurred.");
+        } else {
+          setMessage("An unexpected error occurred.");
+        }
       }
     } catch {
+      abortPaymentRedirect?.();
       // IntegrationError (Element not mounted/ready) rejects instead of returning { error }.
       setMessage(
         "Payment form isn't ready. Please wait a moment and try again.",
@@ -185,8 +197,11 @@ export default function CheckoutForm({
    * POST /api/stripe/create-payment-intent
    */
   createPaymentIntentUrl?: string;
-  /** Called when user starts payment (before redirect to Stripe) so parent can avoid cancelling pending bookings */
-  onPaymentRedirectStart?: () => void;
+  /**
+   * Called when payment confirm is about to redirect. May return an abort fn that runs if
+   * confirm fails without leaving the page.
+   */
+  onPaymentRedirectStart?: () => void | (() => void);
   /**
    * When checkout holds are enabled, reserve capacity before creating the payment intent.
    * Return metadata to merge (e.g. { holdId: "123" }).

--- a/packages/payments/payments-next/src/components/payment-methods.tsx
+++ b/packages/payments/payments-next/src/components/payment-methods.tsx
@@ -68,10 +68,10 @@ type PaymentMethodsProps = {
   checkoutLegal?: CheckoutLegalConfig;
   /**
    * Limit which payment method tabs are offered.
-   * Omit to show all available methods (drop-in, class pass, membership).
+   * Omit to show all available methods (drop-in, class pass, course, membership).
    * Example: `['dropin']` for card/drop-in only (e.g. public event checkout).
    */
-  enabledMethods?: Array<"dropin" | "classpass" | "membership">;
+  enabledMethods?: Array<"dropin" | "classpass" | "membership" | "course">;
 };
 
 type CheckoutSessionInput = {
@@ -113,6 +113,120 @@ export type ClassPassFeeBreakdownComponentProps = {
   classPassTypeId: number;
   classPriceCents: number;
 };
+
+type CourseEnrollmentForTimeslot = {
+  id: number;
+  accessEndsAt?: string | null;
+  course?: number | { id?: number; title?: string | null } | null;
+};
+
+function CourseTabContent({
+  enrollments,
+  isLoading,
+  onConfirm,
+}: {
+  enrollments: CourseEnrollmentForTimeslot[];
+  isLoading?: boolean;
+  onConfirm: (_enrollmentId: number) => Promise<void>;
+}) {
+  const [selectedId, setSelectedId] = useState<number | null>(
+    enrollments.length === 1 && enrollments[0] != null ? enrollments[0].id : null,
+  );
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (enrollments.length === 1 && enrollments[0] != null && selectedId == null) {
+      setSelectedId(enrollments[0].id);
+    }
+  }, [enrollments, selectedId]);
+
+  const handleConfirm = async (enrollmentId?: number) => {
+    const id = enrollmentId ?? selectedId;
+    if (id == null) return;
+    setSelectedId(id);
+    setIsSubmitting(true);
+    try {
+      await onConfirm(id);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="rounded-md bg-muted/40 p-4 text-sm text-muted-foreground animate-pulse">
+        <p>Loading course enrollments…</p>
+      </div>
+    );
+  }
+
+  if (enrollments.length === 0) {
+    return (
+      <div className="rounded-md bg-yellow-50 p-4 text-sm text-yellow-800">
+        <p className="font-medium">No active course enrollment</p>
+        <p className="mt-1">
+          Enroll in a course that covers this class, then return to confirm your booking.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-sm text-muted-foreground">
+        Use a course enrollment to book this timeslot at no extra charge.
+      </p>
+      {enrollments.map((enrollment) => {
+        const courseTitle =
+          typeof enrollment.course === "object" && enrollment.course != null
+            ? enrollment.course.title || "Course"
+            : "Course";
+        const ends =
+          enrollment.accessEndsAt != null
+            ? new Date(enrollment.accessEndsAt).toLocaleDateString()
+            : null;
+        return (
+          <div
+            key={enrollment.id}
+            className="flex items-center justify-between rounded-md border p-3"
+          >
+            <div className="flex flex-col gap-0.5">
+              <span className="font-medium">{courseTitle}</span>
+              {ends ? (
+                <span className="text-sm text-muted-foreground">Access until {ends}</span>
+              ) : null}
+            </div>
+            <div className="flex items-center gap-2">
+              <input
+                type="radio"
+                name="courseEnrollment"
+                checked={selectedId === enrollment.id}
+                onChange={() => setSelectedId(enrollment.id)}
+                className="h-4 w-4"
+              />
+              <button
+                type="button"
+                onClick={() => void handleConfirm(enrollment.id)}
+                disabled={isSubmitting}
+                className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+              >
+                Use this course
+              </button>
+            </div>
+          </div>
+        );
+      })}
+      <button
+        type="button"
+        onClick={() => void handleConfirm()}
+        disabled={selectedId == null || isSubmitting}
+        className="w-full rounded-md bg-primary px-4 py-2 font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+      >
+        {isSubmitting ? "Booking..." : "Confirm with course"}
+      </button>
+    </div>
+  );
+}
 
 function ClassPassTabContent({
   passes,
@@ -354,7 +468,7 @@ export function PaymentMethods({
   const router = useRouter();
   const searchParams = useSearchParams();
   const methodEnabled = useCallback(
-    (method: "dropin" | "classpass" | "membership") =>
+    (method: "dropin" | "classpass" | "membership" | "course") =>
       !enabledMethods || enabledMethods.includes(method),
     [enabledMethods],
   );
@@ -438,6 +552,17 @@ export function PaymentMethods({
       quantity,
     }),
     enabled: methodEnabled("membership"),
+  });
+
+  const {
+    data: validCourseEnrollments = [],
+    isLoading: isLoadingCourseEnrollments,
+    isFetching: isFetchingCourseEnrollments,
+  } = useQuery({
+    ...trpc.bookings.getValidCourseEnrollmentsForTimeslot.queryOptions({
+      timeslotId: timeslot.id,
+    }),
+    enabled: methodEnabled("course"),
   });
 
   // Get valid class passes for this timeslot (Phase 4.6)
@@ -683,6 +808,24 @@ export function PaymentMethods({
     })
   );
 
+  const { mutateAsync: createBookingsWithCourse } = useMutation(
+    trpc.bookings.createBookings.mutationOptions({
+      onSuccess: () => {
+        _onPaymentSuccess?.();
+        onPaymentRedirectStart?.();
+        const url = successUrlProp ?? "/dashboard";
+        router.push(
+          url.startsWith("http")
+            ? url
+            : `${typeof window !== "undefined" ? window.location.origin : ""}${url.startsWith("/") ? url : `/${url}`}`,
+        );
+      },
+      onError: (error: { message?: string }) => {
+        toast.error(error.message || "Failed to book with course enrollment");
+      },
+    }),
+  );
+
   // Wrapper functions that use tRPC
   // planId here is actually the Stripe price ID from the plan's priceJSON
   const handleCreateCheckoutSession = async (
@@ -920,6 +1063,14 @@ export function PaymentMethods({
       classPassesWithEnoughCredits.length > 0 ||
       purchasablePassesForQuantity.length > 0);
 
+  const allowedCourses = (
+    timeslot.eventType as { paymentMethods?: { allowedCourses?: unknown[] } } | null | undefined
+  )?.paymentMethods?.allowedCourses;
+  const hasCourseTab =
+    methodEnabled("course") &&
+    ((Array.isArray(allowedCourses) && allowedCourses.length > 0) ||
+      validCourseEnrollments.length > 0);
+
   // Membership tab: show if there are plans to subscribe/upgrade to, or user has subscription
   // (so we can show "use subscription", "N sessions left", limit reached, or past due + portal)
   let hasMembershipTab =
@@ -959,9 +1110,10 @@ export function PaymentMethods({
     const tabs: string[] = [];
     if (hasDropInTab) tabs.push("dropin");
     if (hasClassPassTab) tabs.push("classpass");
+    if (hasCourseTab) tabs.push("course");
     if (hasMembershipTab) tabs.push("membership");
     return tabs;
-  }, [hasMembershipTab, hasDropInTab, hasClassPassTab]);
+  }, [hasMembershipTab, hasDropInTab, hasClassPassTab, hasCourseTab]);
 
   // Controlled tab so we can auto-switch when the active tab is no longer available
   const defaultTab = availableTabs[0] ?? "dropin";
@@ -993,7 +1145,7 @@ export function PaymentMethods({
   }, [shouldDefaultToMembershipTab, hasMembershipTab, tabManuallySelected]);
 
   // Important: keep this after hooks so changing quantity doesn't break hook order.
-  if (!hasMembershipTab && !hasDropInTab && !hasClassPassTab) {
+  if (!hasMembershipTab && !hasDropInTab && !hasClassPassTab && !hasCourseTab) {
     return (
       <div className="rounded-md bg-yellow-50 p-4 text-sm text-yellow-800">
         <p>
@@ -1025,6 +1177,11 @@ export function PaymentMethods({
               Class pass
             </TabsTrigger>
           )}
+          {hasCourseTab && (
+            <TabsTrigger value="course" className="w-full">
+              Course
+            </TabsTrigger>
+          )}
           {hasMembershipTab && (
             <TabsTrigger value="membership" className="w-full">
               Membership
@@ -1048,6 +1205,22 @@ export function PaymentMethods({
               }}
               onPurchase={handleCreateClassPassCheckout}
               ClassPassFeeBreakdownComponent={ClassPassFeeBreakdownComponent}
+            />
+          </TabsContent>
+        )}
+        {hasCourseTab && (
+          <TabsContent value="course">
+            <CourseTabContent
+              enrollments={validCourseEnrollments as CourseEnrollmentForTimeslot[]}
+              isLoading={isLoadingCourseEnrollments || isFetchingCourseEnrollments}
+              onConfirm={async (courseEnrollmentId: number) => {
+                await createBookingsWithCourse({
+                  timeslotId: timeslot.id,
+                  quantity: hasPendingBookings ? pendingBookingIds.length : quantity,
+                  courseEnrollmentId,
+                  pendingBookingIds: hasPendingBookings ? pendingBookingIds : undefined,
+                });
+              }}
             />
           </TabsContent>
         )}

--- a/packages/shared-services/__tests__/course-enrollment-booking-fields.test.ts
+++ b/packages/shared-services/__tests__/course-enrollment-booking-fields.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import {
+  COURSE_ENROLLMENT_PAYMENT_METHOD,
+  courseEnrollmentBookingFields,
+} from "../src/course-enrollment-booking-fields";
+
+describe("courseEnrollmentBookingFields", () => {
+  it("returns payment method and enrollment id for booking create", () => {
+    expect(courseEnrollmentBookingFields(42)).toEqual({
+      paymentMethodUsed: COURSE_ENROLLMENT_PAYMENT_METHOD,
+      courseEnrollmentIdUsed: 42,
+    });
+  });
+
+  it("uses course_enrollment as the payment method value", () => {
+    expect(COURSE_ENROLLMENT_PAYMENT_METHOD).toBe("course_enrollment");
+  });
+});

--- a/packages/shared-services/__tests__/course-enrollment-valid-for-timeslot.test.ts
+++ b/packages/shared-services/__tests__/course-enrollment-valid-for-timeslot.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Pure filter: enrollments valid for a timeslot (access window + allowed courses/types).
+ */
+import { describe, it, expect } from "vitest";
+import { filterValidEnrollmentsForTimeslot } from "../src/course-enrollment-valid-for-timeslot";
+
+const baseLesson = {
+  tenant: 1,
+  startTime: "2026-09-15T10:00:00.000Z",
+  eventType: {
+    id: 10,
+    paymentMethods: {
+      allowedCourses: [100, 200],
+    },
+  },
+};
+
+const baseEnrollment = {
+  id: 1,
+  tenant: 1,
+  status: "active" as const,
+  accessStartsAt: "2026-09-01T00:00:00.000Z",
+  accessEndsAt: "2026-10-26T23:59:59.999Z",
+  course: {
+    id: 100,
+    status: "open" as const,
+    allowedEventTypes: [10, 11],
+  },
+};
+
+describe("filterValidEnrollmentsForTimeslot", () => {
+  it("keeps an active enrollment in window for an allowed course/type", () => {
+    expect(filterValidEnrollmentsForTimeslot(baseLesson, [baseEnrollment])).toEqual([
+      baseEnrollment,
+    ]);
+  });
+
+  it("rejects cancelled enrollments", () => {
+    expect(
+      filterValidEnrollmentsForTimeslot(baseLesson, [
+        { ...baseEnrollment, status: "cancelled" },
+      ]),
+    ).toEqual([]);
+  });
+
+  it("rejects when timeslot is before accessStartsAt", () => {
+    expect(
+      filterValidEnrollmentsForTimeslot(
+        { ...baseLesson, startTime: "2026-08-31T10:00:00.000Z" },
+        [baseEnrollment],
+      ),
+    ).toEqual([]);
+  });
+
+  it("rejects when timeslot is after accessEndsAt", () => {
+    expect(
+      filterValidEnrollmentsForTimeslot(
+        { ...baseLesson, startTime: "2026-10-27T00:00:00.000Z" },
+        [baseEnrollment],
+      ),
+    ).toEqual([]);
+  });
+
+  it("rejects when course is not in event type allowedCourses", () => {
+    expect(
+      filterValidEnrollmentsForTimeslot(baseLesson, [
+        {
+          ...baseEnrollment,
+          course: { ...baseEnrollment.course, id: 999 },
+        },
+      ]),
+    ).toEqual([]);
+  });
+
+  it("rejects when event type is not in course allowedEventTypes", () => {
+    expect(
+      filterValidEnrollmentsForTimeslot(
+        {
+          ...baseLesson,
+          eventType: {
+            id: 99,
+            paymentMethods: { allowedCourses: [100] },
+          },
+        },
+        [baseEnrollment],
+      ),
+    ).toEqual([]);
+  });
+
+  it("rejects archived courses", () => {
+    expect(
+      filterValidEnrollmentsForTimeslot(baseLesson, [
+        {
+          ...baseEnrollment,
+          course: { ...baseEnrollment.course, status: "archived" },
+        },
+      ]),
+    ).toEqual([]);
+  });
+
+  it("rejects wrong tenant", () => {
+    expect(
+      filterValidEnrollmentsForTimeslot(baseLesson, [
+        { ...baseEnrollment, tenant: 2 },
+      ]),
+    ).toEqual([]);
+  });
+
+  it("returns empty when event type has no allowedCourses", () => {
+    expect(
+      filterValidEnrollmentsForTimeslot(
+        {
+          ...baseLesson,
+          eventType: { id: 10, paymentMethods: { allowedCourses: [] } },
+        },
+        [baseEnrollment],
+      ),
+    ).toEqual([]);
+  });
+});

--- a/packages/shared-services/src/course-enrollment-booking-fields.ts
+++ b/packages/shared-services/src/course-enrollment-booking-fields.ts
@@ -1,0 +1,16 @@
+export const COURSE_ENROLLMENT_PAYMENT_METHOD = "course_enrollment" as const;
+
+export type CourseEnrollmentBookingFields = {
+  paymentMethodUsed: typeof COURSE_ENROLLMENT_PAYMENT_METHOD;
+  courseEnrollmentIdUsed: number;
+};
+
+/** Fields to set on a booking when paying with a course enrollment. */
+export function courseEnrollmentBookingFields(
+  enrollmentId: number,
+): CourseEnrollmentBookingFields {
+  return {
+    paymentMethodUsed: COURSE_ENROLLMENT_PAYMENT_METHOD,
+    courseEnrollmentIdUsed: enrollmentId,
+  };
+}

--- a/packages/shared-services/src/course-enrollment-valid-for-timeslot.ts
+++ b/packages/shared-services/src/course-enrollment-valid-for-timeslot.ts
@@ -1,0 +1,113 @@
+/**
+ * Pure filter: enrollments valid for a timeslot (access window + allowed courses/types).
+ */
+
+export type CourseEnrollmentTimeslotLike = {
+  tenant?: number | { id: number } | null
+  startTime?: string | null
+  eventType?: {
+    id?: number | null
+    paymentMethods?: {
+      allowedCourses?: Array<number | { id: number }> | null
+    } | null
+  } | null
+  classOption?: {
+    id?: number | null
+    paymentMethods?: {
+      allowedCourses?: Array<number | { id: number }> | null
+    } | null
+  } | null
+}
+
+export type CourseEnrollmentLike = {
+  id?: number
+  tenant?: number | { id: number } | null
+  status?: string | null
+  accessStartsAt?: string | null
+  accessEndsAt?: string | null
+  course?:
+    | number
+    | {
+        id?: number | null
+        status?: string | null
+        allowedEventTypes?: Array<number | { id: number }> | null
+      }
+    | null
+}
+
+function toId(
+  val: number | { id?: number | null } | null | undefined,
+): number | null {
+  if (val == null) return null
+  if (typeof val === 'number') return val
+  return typeof val.id === 'number' ? val.id : null
+}
+
+function toIdArray(val: unknown): number[] {
+  if (!Array.isArray(val)) return []
+  return val
+    .map((v) => (typeof v === 'object' && v != null && 'id' in v ? (v as { id: number }).id : v))
+    .filter((v): v is number => typeof v === 'number')
+}
+
+/**
+ * Returns enrollments valid for the timeslot:
+ * same tenant, active, course not archived, course ∈ allowedCourses,
+ * event type ∈ course.allowedEventTypes, timeslot start within access window.
+ */
+export function filterValidEnrollmentsForTimeslot(
+  lesson: CourseEnrollmentTimeslotLike,
+  enrollments: CourseEnrollmentLike[],
+): CourseEnrollmentLike[] {
+  const tenantId = toId(
+    typeof lesson.tenant === 'object' && lesson.tenant != null
+      ? lesson.tenant
+      : (lesson.tenant as number),
+  )
+  const eventTypeId = toId(
+    lesson.eventType?.id != null
+      ? lesson.eventType
+      : lesson.classOption?.id != null
+        ? lesson.classOption
+        : null,
+  )
+  const allowedCourses =
+    lesson.eventType?.paymentMethods?.allowedCourses ??
+    lesson.classOption?.paymentMethods?.allowedCourses ??
+    []
+  const allowedCourseIds = toIdArray(allowedCourses)
+  if (allowedCourseIds.length === 0) return []
+
+  const slotStart = lesson.startTime ? Date.parse(lesson.startTime) : NaN
+  if (!Number.isFinite(slotStart)) return []
+
+  return enrollments.filter((enrollment) => {
+    const enrollmentTenantId = toId(
+      typeof enrollment.tenant === 'object' && enrollment.tenant != null
+        ? enrollment.tenant
+        : (enrollment.tenant as number),
+    )
+    if (tenantId != null && enrollmentTenantId !== tenantId) return false
+    if (enrollment.status !== 'active') return false
+
+    const accessStart = enrollment.accessStartsAt
+      ? Date.parse(enrollment.accessStartsAt)
+      : NaN
+    const accessEnd = enrollment.accessEndsAt
+      ? Date.parse(enrollment.accessEndsAt)
+      : NaN
+    if (!Number.isFinite(accessStart) || !Number.isFinite(accessEnd)) return false
+    if (slotStart < accessStart || slotStart > accessEnd) return false
+
+    const course = enrollment.course
+    if (course == null || typeof course === 'number') return false
+    const courseId = toId(course)
+    if (courseId == null || !allowedCourseIds.includes(courseId)) return false
+    if (course.status === 'archived') return false
+
+    const allowedEventTypeIds = toIdArray(course.allowedEventTypes)
+    if (eventTypeId == null || !allowedEventTypeIds.includes(eventTypeId)) return false
+
+    return true
+  })
+}

--- a/packages/shared-services/src/index.ts
+++ b/packages/shared-services/src/index.ts
@@ -2,6 +2,8 @@ export * from "./timeslot";
 export * from "./subscription";
 export * from "./user";
 export * from "./class-pass-valid-for-lesson";
+export * from "./course-enrollment-valid-for-timeslot";
+export * from "./course-enrollment-booking-fields";
 
 // Export access functions
 // Note: children booking access functions are exported separately to avoid

--- a/packages/shared-types/src/bookings.ts
+++ b/packages/shared-types/src/bookings.ts
@@ -171,7 +171,36 @@ export interface EventType {
     allowedDropIn?: DropIn;
     allowedClassPasses?: ClassPassType[];
     allowedPlans?: Plan[];
+    allowedCourses?: Course[];
   };
+}
+
+export interface Course {
+  id: number;
+  title?: string | null;
+  slug?: string | null;
+  status?: "draft" | "open" | "closed" | "archived" | null;
+  startDate?: string | null;
+  endDate?: string | null;
+  durationLength?: number | null;
+  durationUnit?: "days" | "weeks" | null;
+  allowedEventTypes?: Array<number | EventType> | null;
+  maxEnrollments?: number | null;
+  priceInformation?: {
+    price?: number | null;
+  } | null;
+}
+
+export interface CourseEnrollment {
+  id: number;
+  user?: number | { id: number } | null;
+  course?: number | Course | null;
+  status?: "active" | "cancelled" | "completed" | null;
+  purchasedAt?: string | null;
+  accessStartsAt?: string | null;
+  accessEndsAt?: string | null;
+  transactionId?: string | null;
+  tenant?: number | { id: number } | null;
 }
 
 export interface ClassPassType {

--- a/packages/trpc/src/bookings-slugs.ts
+++ b/packages/trpc/src/bookings-slugs.ts
@@ -9,6 +9,8 @@ export type TRPCBookingCollectionSlugs = {
   bookings: string;
   classPasses: string;
   classPassTypes: string;
+  courseEnrollments: string;
+  courses: string;
 };
 
 export const DEFAULT_TRPC_BOOKING_COLLECTION_SLUGS: TRPCBookingCollectionSlugs = {
@@ -18,6 +20,8 @@ export const DEFAULT_TRPC_BOOKING_COLLECTION_SLUGS: TRPCBookingCollectionSlugs =
   bookings: "bookings",
   classPasses: "class-passes",
   classPassTypes: "class-pass-types",
+  courseEnrollments: "course-enrollments",
+  courses: "courses",
 };
 
 export function mergeTRPCBookingCollectionSlugs(

--- a/packages/trpc/src/routers/bookings.ts
+++ b/packages/trpc/src/routers/bookings.ts
@@ -24,8 +24,11 @@ import {
   getRemainingSessionsInPeriod,
   canUseSubscriptionForBooking,
   filterValidClassPassesForTimeslot,
+  filterValidEnrollmentsForTimeslot,
+  courseEnrollmentBookingFields,
   type TimeslotLike,
   type ClassPassLike,
+  type CourseEnrollmentLike,
 } from "@repo/shared-services";
 import {
   upsertCheckoutHold as upsertCheckoutHoldService,
@@ -46,7 +49,8 @@ export const bookingsRouter = {
    * 3. No payment methods on the lesson → book immediately (free/unlimited)
    * 4. Active subscription covering this lesson, within session limit → book immediately
    * 5. Valid class pass covering this lesson (active, credits > 0, not expired) → book immediately, decrement 1 credit
-   * 6. Subscription limit reached / no entitlement → redirect to /bookings/[id] for payment
+   * 6. Valid course enrollment covering this lesson (active, in access window) → book immediately
+   * 7. Subscription limit reached / no entitlement → redirect to /bookings/[id] for payment
    */
   bookSingleSlotTimeslotOrRedirect: protectedProcedure
     .use(requireBookingCollections("timeslots", "bookings", "eventTypes"))
@@ -105,12 +109,18 @@ export const bookingsRouter = {
       }
 
       const paymentMethods = (eventType as any)?.paymentMethods as
-        | { allowedDropIn?: any; allowedPlans?: any[]; allowedClassPasses?: any[] }
+        | {
+            allowedDropIn?: any
+            allowedPlans?: any[]
+            allowedClassPasses?: any[]
+            allowedCourses?: any[]
+          }
         | undefined;
       const hasPaymentMethods = Boolean(
         paymentMethods?.allowedDropIn ||
           (paymentMethods?.allowedPlans?.length ?? 0) > 0 ||
-          (paymentMethods?.allowedClassPasses?.length ?? 0) > 0
+          (paymentMethods?.allowedClassPasses?.length ?? 0) > 0 ||
+          (paymentMethods?.allowedCourses?.length ?? 0) > 0
       );
 
       const timeslotTenantId =
@@ -272,7 +282,58 @@ export const bookingsRouter = {
         }
       }
 
-      // 6. No entitlement — redirect to booking page for payment.
+      // 6. Valid course enrollment for this timeslot → book immediately (no credits to decrement).
+      const allowedCourseIds: number[] = ((paymentMethods as any)?.allowedCourses ?? [])
+        .map((c: any) => (typeof c === "object" && c != null ? c.id : c))
+        .filter((id: unknown): id is number => typeof id === "number");
+
+      if (
+        allowedCourseIds.length > 0 &&
+        timeslotTenantId != null &&
+        hasCollection(ctx.payload, ctx.bookingsSlugs.courseEnrollments)
+      ) {
+        const slotStartIso =
+          typeof timeslot.startTime === "string"
+            ? timeslot.startTime
+            : new Date(timeslot.startTime as string | number | Date).toISOString();
+        const enrollmentResult = await findSafe(
+          ctx.payload,
+          ctx.bookingsSlugs.courseEnrollments,
+          {
+            where: {
+              and: [
+                { user: { equals: ctx.user.id } },
+                { tenant: { equals: timeslotTenantId } },
+                { course: { in: allowedCourseIds } },
+                { status: { equals: "active" } },
+                { accessStartsAt: { less_than_equal: slotStartIso } },
+                { accessEndsAt: { greater_than_equal: slotStartIso } },
+              ],
+            },
+            limit: 10,
+            depth: 2,
+            sort: "accessEndsAt",
+            overrideAccess: true,
+          },
+        );
+
+        const lessonForFilter = {
+          ...timeslot,
+          eventType: eventType ?? timeslot.eventType,
+        };
+
+        const usableEnrollment = filterValidEnrollmentsForTimeslot(
+          lessonForFilter as Parameters<typeof filterValidEnrollmentsForTimeslot>[0],
+          enrollmentResult.docs as CourseEnrollmentLike[],
+        )[0];
+
+        if (usableEnrollment?.id != null) {
+          await bookOneSlot(courseEnrollmentBookingFields(Number(usableEnrollment.id)));
+          return { redirectUrl: null };
+        }
+      }
+
+      // 7. No entitlement — redirect to booking page for payment.
       return { redirectUrl: `/bookings/${timeslotId}` };
     }),
   checkIn: protectedProcedure
@@ -468,12 +529,24 @@ export const bookingsRouter = {
         pendingBookingIds: z.array(z.number()).optional(),
         /** When provided, bookings are created as confirmed using this class pass (no payment). */
         classPassId: z.number().optional(),
+        /** When provided, bookings are created as confirmed using this course enrollment (no payment). */
+        courseEnrollmentId: z.number().optional(),
       })
     )
     .mutation(async ({ ctx, input }): Promise<Booking[]> => {
-      const { timeslotId, quantity, status: statusInput, subscriptionId, pendingBookingIds, classPassId } = input;
+      const {
+        timeslotId,
+        quantity,
+        status: statusInput,
+        subscriptionId,
+        pendingBookingIds,
+        classPassId,
+        courseEnrollmentId,
+      } = input;
       const status =
-        subscriptionId != null || classPassId != null ? "confirmed" : (statusInput ?? "confirmed");
+        subscriptionId != null || classPassId != null || courseEnrollmentId != null
+          ? "confirmed"
+          : (statusInput ?? "confirmed");
       let tenantId = await resolveTenantId(ctx.payload, getTenantSlug(ctx));
       if (tenantId == null) {
         tenantId = await resolveTenantIdFromTimeslotId(ctx.payload, timeslotId, ctx.bookingsSlugs.timeslots);
@@ -577,7 +650,7 @@ export const bookingsRouter = {
         });
       }
 
-      let paymentMethodUsed: "subscription" | "class_pass" | undefined;
+      let paymentMethodUsed: "subscription" | "class_pass" | "course_enrollment" | undefined;
       let subscriptionIdUsed: number | undefined;
 
       if (subscriptionId != null) {
@@ -776,6 +849,76 @@ export const bookingsRouter = {
         }
         paymentMethodUsed = "class_pass";
         classPassIdUsed = classPassId;
+      }
+
+      let courseEnrollmentIdUsed: number | undefined;
+      if (courseEnrollmentId != null) {
+        if (status !== "confirmed") {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "Booking with course enrollment must be confirmed.",
+          });
+        }
+        if (!hasCollection(ctx.payload, ctx.bookingsSlugs.courseEnrollments)) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "Course enrollments are not available in this application.",
+          });
+        }
+        if (timeslotTenantId == null) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "Timeslot has no tenant.",
+          });
+        }
+
+        // Ensure event type is populated for allowedCourses / allowedEventTypes checks.
+        if (
+          (typeof timeslot.eventType !== "object" || timeslot.eventType == null) &&
+          hasCollection(ctx.payload, ctx.bookingsSlugs.eventTypes)
+        ) {
+          const coId =
+            typeof timeslot.eventType === "number" ? timeslot.eventType : null;
+          if (coId != null) {
+            const populated = await findByIdSafe<EventType>(
+              ctx.payload,
+              ctx.bookingsSlugs.eventTypes,
+              coId,
+              { depth: 1, overrideAccess: true },
+            );
+            if (populated) (timeslot as any).eventType = populated;
+          }
+        }
+
+        const enrollmentResult = await findSafe(
+          ctx.payload,
+          ctx.bookingsSlugs.courseEnrollments,
+          {
+            where: {
+              and: [
+                { id: { equals: courseEnrollmentId } },
+                { user: { equals: ctx.user.id } },
+                { tenant: { equals: timeslotTenantId } },
+                { status: { equals: "active" } },
+              ],
+            },
+            limit: 1,
+            depth: 2,
+            overrideAccess: true,
+          },
+        );
+        const usableEnrollment = filterValidEnrollmentsForTimeslot(
+          timeslot as Parameters<typeof filterValidEnrollmentsForTimeslot>[0],
+          enrollmentResult.docs as CourseEnrollmentLike[],
+        )[0];
+        if (!usableEnrollment) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "Invalid or unauthorized course enrollment for this timeslot.",
+          });
+        }
+        paymentMethodUsed = "course_enrollment";
+        courseEnrollmentIdUsed = courseEnrollmentId;
       }
 
       // When booking via subscription (status confirmed), enforce allowMultipleBookingsPerTimeslot
@@ -993,6 +1136,9 @@ export const bookingsRouter = {
       if (paymentMethodUsed) (baseData as any).paymentMethodUsed = paymentMethodUsed;
       if (subscriptionIdUsed != null) (baseData as any).subscriptionIdUsed = subscriptionIdUsed;
       if (classPassIdUsed != null) (baseData as any).classPassIdUsed = classPassIdUsed;
+      if (courseEnrollmentIdUsed != null) {
+        Object.assign(baseData, courseEnrollmentBookingFields(courseEnrollmentIdUsed));
+      }
 
       const shouldSkipSideEffects = status === "pending";
       for (let i = 0; i < createCount; i++) {
@@ -1075,6 +1221,96 @@ export const bookingsRouter = {
       }
 
       return confirmedBookings;
+    }),
+
+  /**
+   * Returns valid course enrollments for the current user for the given timeslot.
+   */
+  getValidCourseEnrollmentsForTimeslot: protectedProcedure
+    .input(z.object({ timeslotId: z.number() }))
+    .query(async ({ ctx, input }) => {
+      if (
+        !hasCollection(ctx.payload, ctx.bookingsSlugs.timeslots) ||
+        !hasCollection(ctx.payload, ctx.bookingsSlugs.courseEnrollments)
+      ) {
+        return [];
+      }
+
+      let tenantId = await resolveTenantId(ctx.payload, getTenantSlug(ctx));
+      if (tenantId == null) {
+        tenantId = await resolveTenantIdFromTimeslotId(
+          ctx.payload,
+          input.timeslotId,
+          ctx.bookingsSlugs.timeslots,
+        );
+      }
+      const timeslot = await findByIdSafe<Timeslot>(
+        ctx.payload,
+        ctx.bookingsSlugs.timeslots,
+        input.timeslotId,
+        {
+          depth: 2,
+          overrideAccess: Boolean(tenantId),
+          user: ctx.user,
+        },
+      );
+      if (!timeslot) return [];
+
+      await populateTimeslotEventType(
+        ctx.payload,
+        timeslot,
+        ctx.bookingsSlugs.eventTypes,
+        ctx.bookingsSlugs.classPassTypes,
+      );
+
+      const eventType =
+        typeof timeslot.eventType === "object" ? timeslot.eventType : null;
+      const allowedCourses = (
+        eventType as { paymentMethods?: { allowedCourses?: unknown[] } } | null
+      )?.paymentMethods?.allowedCourses;
+      if (!Array.isArray(allowedCourses) || allowedCourses.length === 0) return [];
+
+      const allowedCourseIds = allowedCourses
+        .map((c) => (typeof c === "object" && c != null && "id" in c ? (c as { id: number }).id : c))
+        .filter((id): id is number => typeof id === "number");
+      if (allowedCourseIds.length === 0) return [];
+
+      const timeslotTenantId =
+        typeof timeslot.tenant === "object" && timeslot.tenant != null
+          ? (timeslot.tenant as { id: number }).id
+          : (timeslot.tenant as number | undefined) ?? null;
+      if (timeslotTenantId == null) return [];
+
+      const slotStartIso =
+        typeof timeslot.startTime === "string"
+          ? timeslot.startTime
+          : new Date(timeslot.startTime as string | number | Date).toISOString();
+
+      const result = await findSafe(
+        ctx.payload,
+        ctx.bookingsSlugs.courseEnrollments,
+        {
+          where: {
+            and: [
+              { user: { equals: ctx.user.id } },
+              { tenant: { equals: timeslotTenantId } },
+              { course: { in: allowedCourseIds } },
+              { status: { equals: "active" } },
+              { accessStartsAt: { less_than_equal: slotStartIso } },
+              { accessEndsAt: { greater_than_equal: slotStartIso } },
+            ],
+          },
+          limit: 25,
+          depth: 2,
+          sort: "accessEndsAt",
+          overrideAccess: true,
+        },
+      );
+
+      return filterValidEnrollmentsForTimeslot(
+        timeslot as Parameters<typeof filterValidEnrollmentsForTimeslot>[0],
+        result.docs as CourseEnrollmentLike[],
+      );
     }),
 
   /**

--- a/packages/trpc/src/routers/timeslots.ts
+++ b/packages/trpc/src/routers/timeslots.ts
@@ -818,7 +818,11 @@ export const timeslotsRouter = {
           const hasPaymentMethods = Boolean(
             eventType?.paymentMethods?.allowedDropIn ||
               (Array.isArray(eventType?.paymentMethods?.allowedPlans) &&
-                eventType.paymentMethods.allowedPlans.length > 0)
+                eventType.paymentMethods.allowedPlans.length > 0) ||
+              (Array.isArray(eventType?.paymentMethods?.allowedClassPasses) &&
+                eventType.paymentMethods.allowedClassPasses.length > 0) ||
+              (Array.isArray(eventType?.paymentMethods?.allowedCourses) &&
+                eventType.paymentMethods.allowedCourses.length > 0)
           );
 
           const maxFromCapOrLegacy = (rawMax: any, legacyAllowMultiple?: boolean): number => {
@@ -848,6 +852,14 @@ export const timeslotsRouter = {
             for (const cp of eventType.paymentMethods.allowedClassPasses as any[]) {
               caps.push(maxFromCapOrLegacy(cp?.maxBookingsPerTimeslot, cp?.allowMultipleBookingsPerTimeslot === true))
             }
+          }
+
+          if (
+            Array.isArray(eventType?.paymentMethods?.allowedCourses) &&
+            eventType.paymentMethods.allowedCourses.length > 0
+          ) {
+            // Course enrollments have no per-timeslot credit cap in v1.
+            caps.push(Infinity)
           }
 
           // If there are no payment methods, the flow is "no payment" and multi-booking is allowed


### PR DESCRIPTION
Ship courses with enrollments, guest/auth Stripe purchase, course emails, dedicated platform fee percent, and booking UI so enrolled users can book allowed event types during their access window.