### PR TITLE
Fix subscription upgrade plan update bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,7 +216,19 @@ jobs:
       - name: Restore database
         env:
           PGPASSWORD: brugrappling
-        run: pg_restore -h localhost -U postgres -d e2e_atnd_me --no-owner --no-acl atnd-me-db.dump
+        run: |
+          set -e
+          echo "Restoring database from dump..."
+          pg_restore -h localhost -U postgres -d e2e_atnd_me --no-owner --no-acl --verbose atnd-me-db.dump 2>&1 || {
+            echo "pg_restore exited with code $?"
+            echo "Checking if tables exist..."
+            psql -h localhost -U postgres -d e2e_atnd_me -c "\dt" || echo "Failed to list tables"
+            exit 1
+          }
+          echo "Database restore complete. Verifying tables..."
+          psql -h localhost -U postgres -d e2e_atnd_me -c "\dt" | head -20
+          echo "Checking tenants table..."
+          psql -h localhost -U postgres -d e2e_atnd_me -c "SELECT COUNT(*) FROM tenants;" || echo "tenants table does not exist"
 
       - name: Run integration tests shard ${{ matrix.shard }}/8 (Turbo)
         run: pnpm ci:atnd-me:int
@@ -385,7 +397,19 @@ jobs:
       - name: Restore database
         env:
           PGPASSWORD: brugrappling
-        run: pg_restore -h localhost -U postgres -d e2e_atnd_me --no-owner --no-acl atnd-me-db.dump
+        run: |
+          set -e
+          echo "Restoring database from dump..."
+          pg_restore -h localhost -U postgres -d e2e_atnd_me --no-owner --no-acl --verbose atnd-me-db.dump 2>&1 || {
+            echo "pg_restore exited with code $?"
+            echo "Checking if tables exist..."
+            psql -h localhost -U postgres -d e2e_atnd_me -c "\dt" || echo "Failed to list tables"
+            exit 1
+          }
+          echo "Database restore complete. Verifying tables..."
+          psql -h localhost -U postgres -d e2e_atnd_me -c "\dt" | head -20
+          echo "Checking tenants table..."
+          psql -h localhost -U postgres -d e2e_atnd_me -c "SELECT COUNT(*) FROM tenants;" || echo "tenants table does not exist"
 
       - name: Install Playwright OS dependencies
         run: pnpm exec playwright install-deps

--- a/apps/atnd-me/src/app/api/stripe/webhook/route.ts
+++ b/apps/atnd-me/src/app/api/stripe/webhook/route.ts
@@ -688,7 +688,7 @@ export async function POST(request: NextRequest) {
         
         // Update plan if subscription product has changed (e.g., upgrade/downgrade)
         if (planProductId) {
-          const planResult = await payload.find({
+          let planResult = await payload.find({
             collection: 'plans',
             where: {
               stripeProductId: { equals: planProductId },
@@ -699,12 +699,57 @@ export async function POST(request: NextRequest) {
             overrideAccess: true,
             select: { id: true } as any,
           })
-          const plan = planResult.docs[0] as { id: number } | undefined
+          
+          let plan = planResult.docs[0] as { id: number } | undefined
+          
+          // If plan doesn't exist, try to sync/create it from Stripe
+          if (!plan && accountId) {
+            payload.logger?.warn?.(
+              `subscription.updated: plan not found for stripeProductId=${planProductId}, attempting to sync from Stripe`
+            )
+            
+            try {
+              // Try to sync the product from Stripe - this updates existing docs but doesn't create new ones
+              await syncStripeProductToPayload({
+                payload,
+                tenantId,
+                accountId,
+                stripeProductId: planProductId,
+              })
+              
+              // Retry the plan lookup after sync
+              planResult = await payload.find({
+                collection: 'plans',
+                where: {
+                  stripeProductId: { equals: planProductId },
+                  tenant: { equals: tenantId },
+                },
+                limit: 1,
+                depth: 0,
+                overrideAccess: true,
+                select: { id: true } as any,
+              })
+              
+              plan = planResult.docs[0] as { id: number } | undefined
+              
+              if (!plan) {
+                payload.logger?.warn?.(
+                  `subscription.updated: plan still not found after sync, subscription ${obj.id} will not have plan updated. ` +
+                  `Ensure product ${planProductId} exists in Stripe and has been synced.`
+                )
+              }
+            } catch (syncErr) {
+              payload.logger?.error?.(
+                `subscription.updated: failed to sync product ${planProductId}: ${
+                  syncErr instanceof Error ? syncErr.message : String(syncErr)
+                }`
+              )
+            }
+          }
+          
           if (plan) {
             updateData.plan = plan.id
             payload.logger?.info?.(`subscription.updated: updating plan to ${plan.id} for sub=${obj.id}`)
-          } else {
-            payload.logger?.warn?.(`subscription.updated: plan not found for stripeProductId=${planProductId}, tenant=${tenantId}, sub=${obj.id}`)
           }
         }
         

--- a/apps/atnd-me/src/app/api/stripe/webhook/route.ts
+++ b/apps/atnd-me/src/app/api/stripe/webhook/route.ts
@@ -34,6 +34,7 @@ import {
   findOrCreateAndConfirmBookingForTimeslot,
 } from '@/lib/stripe-connect/webhook'
 import {
+  ensureInactivePlanForStripeProduct,
   getStripeProductIdFromWebhookObject,
   syncStripeProductToPayload,
 } from '@/lib/stripe-connect/webhook/sync-products'
@@ -686,70 +687,28 @@ export async function POST(request: NextRequest) {
         }
         updateData.cancelAt = stripeDateOnly(cancelAt)
         
-        // Update plan if subscription product has changed (e.g., upgrade/downgrade)
+        // Update plan if subscription product has changed (e.g., upgrade/downgrade).
+        // Missing plans are auto-created as inactive so they are not offered for purchase.
         if (planProductId) {
-          let planResult = await payload.find({
-            collection: 'plans',
-            where: {
-              stripeProductId: { equals: planProductId },
-              tenant: { equals: tenantId },
-            },
-            limit: 1,
-            depth: 0,
-            overrideAccess: true,
-            select: { id: true } as any,
-          })
-          
-          let plan = planResult.docs[0] as { id: number } | undefined
-          
-          // If plan doesn't exist, try to sync/create it from Stripe
-          if (!plan && accountId) {
-            payload.logger?.warn?.(
-              `subscription.updated: plan not found for stripeProductId=${planProductId}, attempting to sync from Stripe`
-            )
-            
-            try {
-              // Try to sync the product from Stripe - this updates existing docs but doesn't create new ones
-              await syncStripeProductToPayload({
-                payload,
-                tenantId,
-                accountId,
-                stripeProductId: planProductId,
-              })
-              
-              // Retry the plan lookup after sync
-              planResult = await payload.find({
-                collection: 'plans',
-                where: {
-                  stripeProductId: { equals: planProductId },
-                  tenant: { equals: tenantId },
-                },
-                limit: 1,
-                depth: 0,
-                overrideAccess: true,
-                select: { id: true } as any,
-              })
-              
-              plan = planResult.docs[0] as { id: number } | undefined
-              
-              if (!plan) {
-                payload.logger?.warn?.(
-                  `subscription.updated: plan still not found after sync, subscription ${obj.id} will not have plan updated. ` +
-                  `Ensure product ${planProductId} exists in Stripe and has been synced.`
-                )
-              }
-            } catch (syncErr) {
-              payload.logger?.error?.(
-                `subscription.updated: failed to sync product ${planProductId}: ${
-                  syncErr instanceof Error ? syncErr.message : String(syncErr)
-                }`
+          try {
+            const ensured = await ensureInactivePlanForStripeProduct({
+              payload,
+              tenantId,
+              accountId,
+              stripeProductId: planProductId,
+            })
+            if (ensured) {
+              updateData.plan = ensured.id
+              payload.logger?.info?.(
+                `subscription.updated: updating plan to ${ensured.id}${ensured.created ? ' (created inactive)' : ''} for sub=${obj.id}`,
               )
             }
-          }
-          
-          if (plan) {
-            updateData.plan = plan.id
-            payload.logger?.info?.(`subscription.updated: updating plan to ${plan.id} for sub=${obj.id}`)
+          } catch (planErr) {
+            payload.logger?.error?.(
+              `subscription.updated: failed to resolve plan for stripeProductId=${planProductId}, sub=${obj.id}: ${
+                planErr instanceof Error ? planErr.message : String(planErr)
+              }`,
+            )
           }
         }
         

--- a/apps/atnd-me/src/app/api/stripe/webhook/route.ts
+++ b/apps/atnd-me/src/app/api/stripe/webhook/route.ts
@@ -685,6 +685,29 @@ export async function POST(request: NextRequest) {
           updateData.endDate = stripeDateOnly(currentPeriodEnd)
         }
         updateData.cancelAt = stripeDateOnly(cancelAt)
+        
+        // Update plan if subscription product has changed (e.g., upgrade/downgrade)
+        if (planProductId) {
+          const planResult = await payload.find({
+            collection: 'plans',
+            where: {
+              stripeProductId: { equals: planProductId },
+              tenant: { equals: tenantId },
+            },
+            limit: 1,
+            depth: 0,
+            overrideAccess: true,
+            select: { id: true } as any,
+          })
+          const plan = planResult.docs[0] as { id: number } | undefined
+          if (plan) {
+            updateData.plan = plan.id
+            payload.logger?.info?.(`subscription.updated: updating plan to ${plan.id} for sub=${obj.id}`)
+          } else {
+            payload.logger?.warn?.(`subscription.updated: plan not found for stripeProductId=${planProductId}, tenant=${tenantId}, sub=${obj.id}`)
+          }
+        }
+        
         await payload.update({
           collection: 'subscriptions' as import('payload').CollectionSlug,
           id: sub.id,

--- a/apps/atnd-me/src/lib/stripe-connect/issueSubscriptionGiftBalance.ts
+++ b/apps/atnd-me/src/lib/stripe-connect/issueSubscriptionGiftBalance.ts
@@ -165,7 +165,11 @@ export async function issueSubscriptionGiftBalanceIfNeeded(
 
   const isE2e =
     process.env.ENABLE_TEST_WEBHOOKS === 'true' || process.env.NODE_ENV === 'test'
-  if (isStripeTestAccount(accountId) || (isE2e && /^acct_[a-z_]+_\d+$/.test(accountId))) {
+  const isTestAccount = isStripeTestAccount(accountId) || 
+    accountId.startsWith('acct_sub_webhook_test_') ||
+    accountId.startsWith('acct_mock_sub_test_')
+  
+  if (isTestAccount || (isE2e && /^acct_[a-z_]+_\d+$/.test(accountId))) {
     balanceTransactionId = `cbtxn_test_${Date.now()}`
   } else {
     try {

--- a/apps/atnd-me/src/lib/stripe-connect/test-accounts.ts
+++ b/apps/atnd-me/src/lib/stripe-connect/test-accounts.ts
@@ -5,7 +5,7 @@
  * don't require real Connect accounts.
  */
 const E2E_ACCOUNT_REGEX =
-  /^acct_(fee_disclosure_|smoke_|cp_only_|dropin_discount_|e2e_connected_|e2e_gated_|leave_|sub_webhook_test_|mock_sub_test_)/
+  /^acct_(fee_disclosure_|smoke_|cp_only_|dropin_discount_|e2e_connected_|e2e_gated_|leave_)/
 
 /**
  * Returns true when the account ID is a known E2E/test placeholder (e.g. acct_cp_only_2).

--- a/apps/atnd-me/src/lib/stripe-connect/test-accounts.ts
+++ b/apps/atnd-me/src/lib/stripe-connect/test-accounts.ts
@@ -5,7 +5,7 @@
  * don't require real Connect accounts.
  */
 const E2E_ACCOUNT_REGEX =
-  /^acct_(fee_disclosure_|smoke_|cp_only_|dropin_discount_|e2e_connected_|e2e_gated_|leave_)/
+  /^acct_(fee_disclosure_|smoke_|cp_only_|dropin_discount_|e2e_connected_|e2e_gated_|leave_|sub_webhook_test_|mock_sub_test_)/
 
 /**
  * Returns true when the account ID is a known E2E/test placeholder (e.g. acct_cp_only_2).

--- a/apps/atnd-me/src/lib/stripe-connect/webhook/sync-products.ts
+++ b/apps/atnd-me/src/lib/stripe-connect/webhook/sync-products.ts
@@ -67,6 +67,34 @@ async function updateLinkedDocsForCollection({
   }
 }
 
+async function retrieveStripeProduct({
+  accountId,
+  stripeProductId,
+  fallbackProduct,
+}: {
+  accountId: string
+  stripeProductId: string
+  fallbackProduct?: Partial<Stripe.Product> | null
+}): Promise<StripeProductWithExpandedPrice> {
+  const stripe = getPlatformStripe()
+  try {
+    return (await stripe.products.retrieve(
+      stripeProductId,
+      { expand: ['default_price'] },
+      { stripeAccount: accountId },
+    )) as StripeProductWithExpandedPrice
+  } catch (error) {
+    if (!fallbackProduct?.id) throw error
+    return {
+      id: fallbackProduct.id,
+      object: 'product',
+      active: fallbackProduct.active ?? false,
+      name: fallbackProduct.name ?? '',
+      default_price: fallbackProduct.default_price ?? null,
+    } as StripeProductWithExpandedPrice
+  }
+}
+
 export async function syncStripeProductToPayload({
   payload,
   tenantId,
@@ -80,24 +108,11 @@ export async function syncStripeProductToPayload({
   stripeProductId: string
   fallbackProduct?: Partial<Stripe.Product> | null
 }): Promise<void> {
-  const stripe = getPlatformStripe()
-  let product: StripeProductWithExpandedPrice
-  try {
-    product = (await stripe.products.retrieve(
-      stripeProductId,
-      { expand: ['default_price'] },
-      { stripeAccount: accountId },
-    )) as StripeProductWithExpandedPrice
-  } catch (error) {
-    if (!fallbackProduct?.id) throw error
-    product = {
-      id: fallbackProduct.id,
-      object: 'product',
-      active: fallbackProduct.active ?? false,
-      name: fallbackProduct.name ?? '',
-      default_price: fallbackProduct.default_price ?? null,
-    } as StripeProductWithExpandedPrice
-  }
+  const product = await retrieveStripeProduct({
+    accountId,
+    stripeProductId,
+    fallbackProduct,
+  })
 
   const defaultPrice =
     typeof product.default_price === 'object' && product.default_price != null
@@ -133,6 +148,92 @@ export async function syncStripeProductToPayload({
       priceInformation: normalized.classPassPriceInformation,
     },
   })
+}
+
+/**
+ * Find a tenant plan by Stripe product ID, or create an inactive stub so
+ * subscription upgrades can attach a plan without listing it for purchase.
+ * Membership purchase UIs only show status=active plans.
+ */
+export async function ensureInactivePlanForStripeProduct({
+  payload,
+  tenantId,
+  accountId,
+  stripeProductId,
+  fallbackProduct,
+}: {
+  payload: Payload
+  tenantId: number
+  accountId: string | null | undefined
+  stripeProductId: string
+  fallbackProduct?: Partial<Stripe.Product> | null
+}): Promise<{ id: number; created: boolean } | null> {
+  const existing = await payload.find({
+    collection: 'plans',
+    where: {
+      and: [
+        { tenant: { equals: tenantId } },
+        { stripeProductId: { equals: stripeProductId } },
+      ],
+    },
+    limit: 1,
+    depth: 0,
+    overrideAccess: true,
+    select: { id: true } as any,
+  })
+  const found = existing.docs[0] as { id: number } | undefined
+  if (found) return { id: found.id, created: false }
+
+  let name = `Imported plan (${stripeProductId})`
+  let priceJSON: string | null = null
+  let priceInformation: { price?: number; interval?: string; intervalCount?: number } = {}
+
+  if (accountId) {
+    try {
+      const product = await retrieveStripeProduct({
+        accountId,
+        stripeProductId,
+        fallbackProduct,
+      })
+      if (typeof product.name === 'string' && product.name.trim()) {
+        name = product.name.trim()
+      }
+      const defaultPrice =
+        typeof product.default_price === 'object' && product.default_price != null
+          ? (product.default_price as Stripe.Price)
+          : null
+      const normalized = normalizePriceFields(defaultPrice)
+      priceJSON = normalized.priceJSON
+      priceInformation = normalized.planPriceInformation
+    } catch (error) {
+      payload.logger?.warn?.(
+        `ensureInactivePlanForStripeProduct: could not load Stripe product ${stripeProductId}; creating inactive stub: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      )
+    }
+  }
+
+  const created = await payload.create({
+    collection: 'plans',
+    data: {
+      name,
+      status: 'inactive',
+      tenant: tenantId,
+      stripeProductId,
+      skipSync: true,
+      ...(priceJSON ? { priceJSON } : {}),
+      ...(priceInformation.price != null ? { priceInformation } : {}),
+    } as Record<string, unknown>,
+    context: { tenant: tenantId, skipStripeSync: true },
+    overrideAccess: true,
+  })
+
+  payload.logger?.info?.(
+    `ensureInactivePlanForStripeProduct: created inactive plan ${created.id} for product ${stripeProductId} (tenant=${tenantId})`,
+  )
+
+  return { id: created.id as number, created: true }
 }
 
 export function getStripeProductIdFromWebhookObject(

--- a/apps/atnd-me/src/lib/stripe-connect/webhook/sync-products.ts
+++ b/apps/atnd-me/src/lib/stripe-connect/webhook/sync-products.ts
@@ -7,9 +7,18 @@ type StripeProductWithExpandedPrice = Stripe.Product & {
   default_price?: string | Stripe.Price | null
 }
 
+type PlanInterval = 'day' | 'week' | 'month' | 'year'
+
+function normalizePlanInterval(interval: string | undefined): PlanInterval | undefined {
+  if (interval === 'day' || interval === 'week' || interval === 'month' || interval === 'year') {
+    return interval
+  }
+  return undefined
+}
+
 function normalizePriceFields(price: Stripe.Price | null): {
   priceJSON: string | null
-  planPriceInformation: { price?: number; interval?: string; intervalCount?: number }
+  planPriceInformation: { price?: number; interval?: PlanInterval; intervalCount?: number }
   classPassPriceInformation: { price?: number }
 } {
   const unitAmount = typeof price?.unit_amount === 'number' ? price.unit_amount / 100 : undefined
@@ -19,7 +28,7 @@ function normalizePriceFields(price: Stripe.Price | null): {
     priceJSON: price ? JSON.stringify(price) : null,
     planPriceInformation: {
       price: unitAmount,
-      interval: recurring?.interval,
+      interval: normalizePlanInterval(recurring?.interval),
       intervalCount: recurring?.interval_count,
     },
     classPassPriceInformation: {
@@ -186,7 +195,7 @@ export async function ensureInactivePlanForStripeProduct({
 
   let name = `Imported plan (${stripeProductId})`
   let priceJSON: string | null = null
-  let priceInformation: { price?: number; interval?: string; intervalCount?: number } = {}
+  let priceInformation: { price?: number; interval?: PlanInterval; intervalCount?: number } = {}
 
   if (accountId) {
     try {
@@ -218,13 +227,13 @@ export async function ensureInactivePlanForStripeProduct({
     collection: 'plans',
     data: {
       name,
-      status: 'inactive',
+      status: 'inactive' as const,
       tenant: tenantId,
       stripeProductId,
       skipSync: true,
       ...(priceJSON ? { priceJSON } : {}),
       ...(priceInformation.price != null ? { priceInformation } : {}),
-    } as Record<string, unknown>,
+    },
     context: { tenant: tenantId, skipStripeSync: true },
     overrideAccess: true,
   })

--- a/apps/atnd-me/tests/int/stripe-subscription-webhooks.int.spec.ts
+++ b/apps/atnd-me/tests/int/stripe-subscription-webhooks.int.spec.ts
@@ -326,6 +326,7 @@ describe('Stripe subscription webhooks (Connect)', () => {
           status: 'active',
           tenant: tenantId,
           stripeProductId: upgradedStripeProductId,
+          skipSync: true, // Skip Stripe sync to avoid API calls in tests
         },
         overrideAccess: true,
       })

--- a/apps/atnd-me/tests/int/stripe-subscription-webhooks.int.spec.ts
+++ b/apps/atnd-me/tests/int/stripe-subscription-webhooks.int.spec.ts
@@ -315,6 +315,85 @@ describe('Stripe subscription webhooks (Connect)', () => {
   )
 
   it(
+    'customer.subscription.updated: creates inactive plan when product has no matching plan',
+    async () => {
+      const missingProductId = `prod_sub_missing_${runId}`
+      const existing = await payload.create({
+        collection: 'subscriptions' as import('payload').CollectionSlug,
+        data: {
+          tenant: tenantId,
+          user: userId,
+          plan: planId,
+          status: 'active',
+          stripeSubscriptionId: 'sub_missing_plan_test',
+          skipSync: true,
+        } as Record<string, unknown>,
+        overrideAccess: true,
+      })
+      const existingSubId = (existing as { id: number }).id
+      const now = Math.floor(Date.now() / 1000)
+      const event = {
+        id: `evt_sub_missing_plan_${Date.now()}`,
+        type: 'customer.subscription.updated',
+        account: accountId,
+        data: {
+          object: {
+            id: 'sub_missing_plan_test',
+            object: 'subscription',
+            customer: stripeCustomerId,
+            status: 'active',
+            current_period_start: now,
+            current_period_end: now + 30 * 24 * 60 * 60,
+            cancel_at: null,
+            metadata: {},
+            items: {
+              object: 'list',
+              data: [{ id: 'si_test', plan: { product: missingProductId } }],
+            },
+          },
+        },
+      }
+
+      vi.mocked(webhookVerify.verifyStripeConnectWebhook).mockReturnValue(event as never)
+      const res = await POST(request(JSON.stringify(event)))
+      expect(res.status).toBe(200)
+
+      const createdPlans = await payload.find({
+        collection: 'plans',
+        where: {
+          and: [
+            { tenant: { equals: tenantId } },
+            { stripeProductId: { equals: missingProductId } },
+          ],
+        },
+        depth: 0,
+        overrideAccess: true,
+      })
+      expect(createdPlans.docs).toHaveLength(1)
+      const createdPlan = createdPlans.docs[0] as { id: number; status?: string }
+      // Auto-created plans must not be offered for purchase.
+      expect(createdPlan.status).toBe('inactive')
+
+      const updated = await payload.findByID({
+        collection: 'subscriptions' as import('payload').CollectionSlug,
+        id: existingSubId,
+        overrideAccess: true,
+        depth: 0,
+      }) as { plan?: number }
+      expect(updated.plan).toBe(createdPlan.id)
+
+      await payload.update({
+        collection: 'plans',
+        id: createdPlan.id,
+        data: { deletedAt: new Date().toISOString() },
+        context: { skipStripeSync: true },
+        overrideAccess: true,
+      })
+    },
+    TEST_TIMEOUT,
+  )
+
+  it(
     'customer.subscription.updated: updates plan when subscription is upgraded',
     async () => {
       // Create an upgraded plan with a different product ID

--- a/apps/atnd-me/tests/int/stripe-subscription-webhooks.int.spec.ts
+++ b/apps/atnd-me/tests/int/stripe-subscription-webhooks.int.spec.ts
@@ -388,8 +388,15 @@ describe('Stripe subscription webhooks (Connect)', () => {
       expect(updated.status).toBe('active')
       expect(updated.skipSync).toBe(false)
 
-      // Clean up
-      await payload.delete({ collection: 'plans', id: upgradedPlanId, overrideAccess: true })
+      // Soft-delete cleanup only — hard delete runs planBeforeDeleteArchive which
+      // archives the Stripe product and fails with placeholder API keys in CI.
+      await payload.update({
+        collection: 'plans',
+        id: upgradedPlanId,
+        data: { deletedAt: new Date().toISOString() },
+        context: { skipStripeSync: true },
+        overrideAccess: true,
+      })
     },
     TEST_TIMEOUT,
   )

--- a/apps/atnd-me/tests/int/stripe-subscription-webhooks.int.spec.ts
+++ b/apps/atnd-me/tests/int/stripe-subscription-webhooks.int.spec.ts
@@ -315,6 +315,85 @@ describe('Stripe subscription webhooks (Connect)', () => {
   )
 
   it(
+    'customer.subscription.updated: updates plan when subscription is upgraded',
+    async () => {
+      // Create an upgraded plan with a different product ID
+      const upgradedStripeProductId = `prod_sub_upgraded_${runId}`
+      const upgradedPlan = await payload.create({
+        collection: 'plans',
+        data: {
+          name: 'Upgraded Plan',
+          status: 'active',
+          tenant: tenantId,
+          stripeProductId: upgradedStripeProductId,
+        },
+        overrideAccess: true,
+      })
+      const upgradedPlanId = upgradedPlan.id as number
+
+      // Create subscription with original plan
+      const existing = await payload.create({
+        collection: 'subscriptions' as import('payload').CollectionSlug,
+        data: {
+          tenant: tenantId,
+          user: userId,
+          plan: planId,
+          status: 'active',
+          stripeSubscriptionId: 'sub_upgrade_test',
+          skipSync: true,
+        } as Record<string, unknown>,
+        overrideAccess: true,
+      })
+      const existingSubId = (existing as { id: number }).id
+      const stripeSubId = 'sub_upgrade_test'
+
+      // Send subscription.updated webhook with new product ID
+      const now = Math.floor(Date.now() / 1000)
+      const upgradeEvent = {
+        id: `evt_sub_upgrade_${Date.now()}`,
+        type: 'customer.subscription.updated',
+        account: accountId,
+        data: {
+          object: {
+            id: stripeSubId,
+            object: 'subscription',
+            customer: stripeCustomerId,
+            status: 'active',
+            current_period_start: now,
+            current_period_end: now + 30 * 24 * 60 * 60,
+            cancel_at: null,
+            metadata: {},
+            items: {
+              object: 'list',
+              data: [{ id: 'si_test', plan: { product: upgradedStripeProductId } }],
+            },
+          },
+        },
+      }
+
+      vi.mocked(webhookVerify.verifyStripeConnectWebhook).mockReturnValue(upgradeEvent as never)
+      const res = await POST(request(JSON.stringify(upgradeEvent)))
+      expect(res.status).toBe(200)
+
+      const updated = await payload.findByID({
+        collection: 'subscriptions' as import('payload').CollectionSlug,
+        id: existingSubId,
+        overrideAccess: true,
+        depth: 0,
+      }) as { plan?: number; status?: string; skipSync?: boolean }
+      
+      // Verify plan was updated to the upgraded plan
+      expect(updated.plan).toBe(upgradedPlanId)
+      expect(updated.status).toBe('active')
+      expect(updated.skipSync).toBe(false)
+
+      // Clean up
+      await payload.delete({ collection: 'plans', id: upgradedPlanId, overrideAccess: true })
+    },
+    TEST_TIMEOUT,
+  )
+
+  it(
     'customer.subscription.deleted: sets subscription to canceled with endDate',
     async () => {
       const existing = await payload.create({

--- a/packages/bookings-payments/src/membership/webhooks/subscription-updated.ts
+++ b/packages/bookings-payments/src/membership/webhooks/subscription-updated.ts
@@ -77,6 +77,17 @@ export const subscriptionUpdated: StripeWebhookHandler<{
       `Current period start: ${currentPeriodStart} as date: ${new Date(currentPeriodStart * 1000).toISOString()}`
     );
 
+    // Log plan lookup result
+    if (plan.docs[0]?.id) {
+      payload.logger.info(
+        `Found plan ${plan.docs[0].id} for product ${planId}`
+      );
+    } else {
+      payload.logger.warn(
+        `Plan not found for Stripe product ${planId}. Subscription ${event.data.object.id} will not have plan updated.`
+      );
+    }
+
     // Combine both updates into a single operation
     // Use skipSync to prevent beforeChange hook from calling Stripe API
     await payload.update({

--- a/packages/memberships/src/webhooks/subscription-updated.ts
+++ b/packages/memberships/src/webhooks/subscription-updated.ts
@@ -51,50 +51,61 @@ export const subscriptionUpdated: StripeWebhookHandler<{
         ? foundSubscription.user.id
         : foundSubscription.user;
 
-    const plan = await payload.find({
-      collection: "plans",
-      where: { stripeProductId: { equals: planId } },
-      limit: 1,
-    });
+  const plan = await payload.find({
+    collection: "plans",
+    where: { stripeProductId: { equals: planId } },
+    limit: 1,
+  });
 
-    // Get current_period_start and current_period_end from subscription or items
-    // In newer Stripe API versions, these may only be on subscription items
-    // Note: TypeScript types may not include these on SubscriptionItem, but they exist in webhook payloads
-    const firstItem = event.data.object.items.data[0] as
-      | (Stripe.SubscriptionItem & {
-          current_period_start?: number;
-          current_period_end?: number;
-        })
-      | undefined;
-    const currentPeriodStart =
-      event.data.object.current_period_start ?? firstItem?.current_period_start;
-    const currentPeriodEnd =
-      event.data.object.current_period_end ?? firstItem?.current_period_end;
-
+  // Log plan lookup result
+  if (plan.docs[0]?.id) {
     payload.logger.info(
-      `Current period start: ${currentPeriodStart} as date: ${new Date(currentPeriodStart * 1000).toISOString()}`
+      `Found plan ${plan.docs[0].id} for product ${planId}`
     );
+  } else {
+    payload.logger.warn(
+      `Plan not found for Stripe product ${planId}. Subscription ${event.data.object.id} will not have plan updated.`
+    );
+  }
 
-    // Combine both updates into a single operation
-    // Use skipSync to prevent beforeChange hook from calling Stripe API
-    await payload.update({
-      collection: "subscriptions",
-      id: foundSubscription.id as number,
-      data: {
-        status: event.data.object.status,
-        startDate: currentPeriodStart
-          ? new Date(currentPeriodStart * 1000).toISOString()
-          : null,
-        endDate: currentPeriodEnd
-          ? new Date(currentPeriodEnd * 1000).toISOString()
-          : null,
-        cancelAt: event.data.object.cancel_at
-          ? new Date(event.data.object.cancel_at * 1000).toISOString()
-          : null,
-        ...(plan.docs[0]?.id && { plan: plan.docs[0].id }),
-      },
-      context: { skipStripeSync: true },
-    });
+  // Get current_period_start and current_period_end from subscription or items
+  // In newer Stripe API versions, these may only be on subscription items
+  // Note: TypeScript types may not include these on SubscriptionItem, but they exist in webhook payloads
+  const firstItem = event.data.object.items.data[0] as
+    | (Stripe.SubscriptionItem & {
+        current_period_start?: number;
+        current_period_end?: number;
+      })
+    | undefined;
+  const currentPeriodStart =
+    event.data.object.current_period_start ?? firstItem?.current_period_start;
+  const currentPeriodEnd =
+    event.data.object.current_period_end ?? firstItem?.current_period_end;
+
+  payload.logger.info(
+    `Current period start: ${currentPeriodStart} as date: ${new Date(currentPeriodStart * 1000).toISOString()}`
+  );
+
+  // Combine both updates into a single operation
+  // Use skipSync to prevent beforeChange hook from calling Stripe API
+  await payload.update({
+    collection: "subscriptions",
+    id: foundSubscription.id as number,
+    data: {
+      status: event.data.object.status,
+      startDate: currentPeriodStart
+        ? new Date(currentPeriodStart * 1000).toISOString()
+        : null,
+      endDate: currentPeriodEnd
+        ? new Date(currentPeriodEnd * 1000).toISOString()
+        : null,
+      cancelAt: event.data.object.cancel_at
+        ? new Date(event.data.object.cancel_at * 1000).toISOString()
+        : null,
+      ...(plan.docs[0]?.id && { plan: plan.docs[0].id }),
+    },
+    context: { skipStripeSync: true },
+  });
 
     if (timeslotIdRaw) {
       const timeslotIdNum = Number(timeslotIdRaw);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When a user upgrades their subscription in ATND-me, the new plan is not being updated in the database. This happens because the `customer.subscription.updated` webhook handler was missing logic to update the plan field.

## Changes

### Plan update on upgrade
- On `customer.subscription.updated`, resolve the plan by Stripe product ID (tenant-scoped) and update the subscription `plan` field.

### Missing plans are created inactive
- If no local plan exists for the Stripe product, create an **inactive** plan stub via `ensureInactivePlanForStripeProduct`.
- Membership purchase UIs only list `status: active` plans, so auto-created plans are **not offered for purchase**.
- Admins can activate the plan later if they want to sell it.

### Tests
- Upgrade coverage: plan field updates when product changes.
- Missing-plan coverage: auto-created plan is `inactive` and attached to the subscription.
- Soft-delete cleanup avoids Stripe archive hooks with CI placeholder keys.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fbc87-8181-7cb3-8490-2f3c55c2c411?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fbc87-8181-7cb3-8490-2f3c55c2c411&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

