### PR TITLE
fix: schedule next-day post-booking emails from class start time

### DIFF
--- a/apps/atnd-me/src/fields/postBookingEmailFields.ts
+++ b/apps/atnd-me/src/fields/postBookingEmailFields.ts
@@ -4,7 +4,10 @@ import { buildFormStyleEmailsField } from './formEmailFields'
 export const POST_BOOKING_EMAIL_SEND_TIMING_OPTIONS = [
   { label: 'Immediately after all bookings', value: 'after_all_bookings' },
   { label: 'Immediately after first booking', value: 'after_first_booking' },
-  { label: 'The next day following first booking', value: 'next_day_after_first_booking' },
+  {
+    label: '9am the day after the first class',
+    value: 'next_day_after_first_booking',
+  },
 ] as const
 
 export type PostBookingEmailSendTiming =

--- a/apps/atnd-me/src/lib/post-booking-email/maybe-trigger-post-booking-email.ts
+++ b/apps/atnd-me/src/lib/post-booking-email/maybe-trigger-post-booking-email.ts
@@ -134,7 +134,18 @@ async function maybeTriggerSinglePostBookingEmail({
       overrideAccess: true,
     })
     const timeZone = resolveTimeslotTimeZone(timeslot as Parameters<typeof resolveTimeslotTimeZone>[0])
-    const scheduledFor = resolveNextDay9am(new Date(), timeZone).toISOString()
+    const timeslotStartTime =
+      timeslot && typeof timeslot === 'object' && 'startTime' in timeslot
+        ? (timeslot as { startTime?: unknown }).startTime
+        : null
+    if (typeof timeslotStartTime !== 'string' && !(timeslotStartTime instanceof Date)) {
+      req.payload.logger.error(
+        `[post-booking-email] Missing timeslot startTime for timeslot ${timeslotId}; skipping next-day schedule`,
+      )
+      return
+    }
+    // 9am local on the calendar day after the booked class, not after checkout.
+    const scheduledFor = resolveNextDay9am(timeslotStartTime, timeZone).toISOString()
 
     const delivery = await createDeliveryRecord(req, {
       tenantId,

--- a/apps/atnd-me/src/lib/post-booking-email/maybe-trigger-post-booking-email.ts
+++ b/apps/atnd-me/src/lib/post-booking-email/maybe-trigger-post-booking-email.ts
@@ -145,7 +145,10 @@ async function maybeTriggerSinglePostBookingEmail({
       return
     }
     // 9am local on the calendar day after the booked class, not after checkout.
-    const scheduledFor = resolveNextDay9am(timeslotStartTime, timeZone).toISOString()
+    // Normalize via Date so we persist UTC ISO (TZDate.toISOString may keep +01:00).
+    const scheduledFor = new Date(
+      resolveNextDay9am(timeslotStartTime, timeZone),
+    ).toISOString()
 
     const delivery = await createDeliveryRecord(req, {
       tenantId,

--- a/apps/atnd-me/src/lib/post-booking-email/resolve-send-time.ts
+++ b/apps/atnd-me/src/lib/post-booking-email/resolve-send-time.ts
@@ -3,10 +3,13 @@ import { getZonedDateParts } from '@repo/shared-utils'
 
 const NEXT_DAY_SEND_HOUR = 9
 
+/**
+ * 9:00 local on the calendar day after `anchorAt` (typically the timeslot start).
+ */
 export function resolveNextDay9am(
-  confirmedAt: Date | string | number,
+  anchorAt: Date | string | number,
   timeZone: string,
 ): Date {
-  const { year, month, date } = getZonedDateParts(confirmedAt, timeZone)
+  const { year, month, date } = getZonedDateParts(anchorAt, timeZone)
   return new TZDate(year, month, date + 1, NEXT_DAY_SEND_HOUR, 0, 0, 0, timeZone)
 }

--- a/apps/atnd-me/tests/e2e/helpers/scheduler-e2e-helpers.ts
+++ b/apps/atnd-me/tests/e2e/helpers/scheduler-e2e-helpers.ts
@@ -711,12 +711,14 @@ export async function getSchedulerTimeSlotCountFromDB(
   return Array.isArray(timeSlot) ? timeSlot.length : 0
 }
 
-/** Expand every day row in the scheduler week.days array. */
+/** Expand every day row (and nested timeSlot arrays) in the scheduler week.days form. */
 export async function ensureAllSchedulerDaysExpanded(page: Page): Promise<void> {
-  const showAll = page.getByRole('button', { name: 'Show All' })
-  if (await showAll.isVisible().catch(() => false)) {
+  // Days + nested timeSlot arrays each expose "Show All"; click until none remain.
+  for (let i = 0; i < 10; i += 1) {
+    const showAll = page.getByRole('button', { name: 'Show All' }).first()
+    if (!(await showAll.isVisible().catch(() => false))) break
     await showAll.click({ timeout: 15_000 })
-    await page.waitForTimeout(500)
+    await page.waitForTimeout(300)
   }
 }
 

--- a/apps/atnd-me/tests/int/post-booking-email.int.spec.ts
+++ b/apps/atnd-me/tests/int/post-booking-email.int.spec.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
 import { getPayload, type Payload } from 'payload'
 import config from '@/payload.config'
 import { POST_BOOKING_EMAIL_DELIVERIES_SLUG } from '@/collections/PostBookingEmailDeliveries'
+import { resolveNextDay9am } from '@/lib/post-booking-email/resolve-send-time'
+import { resolveTimeslotTimeZone } from '@repo/shared-utils'
 
 const HOOK_TIMEOUT = 300000
 const TEST_TIMEOUT = 60000
@@ -448,10 +450,12 @@ describe('Post-booking email integration', () => {
         overrideAccess: true,
       })
 
+      // Class is several days out so a booking-day schedule would differ from class-day.
       const start = new Date()
-      start.setHours(14, 0, 0, 0)
+      start.setUTCDate(start.getUTCDate() + 5)
+      start.setUTCHours(14, 0, 0, 0)
       const end = new Date(start)
-      end.setHours(15, 0, 0, 0)
+      end.setUTCHours(15, 0, 0, 0)
 
       const nextDayTimeslot = await payload.create({
         collection: 'timeslots',
@@ -497,6 +501,15 @@ describe('Post-booking email integration', () => {
 
       expect(deliveriesBeforeCancel.totalDocs).toBe(1)
       expect(deliveriesBeforeCancel.docs[0]?.status).toBe('scheduled')
+
+      const timeZone = resolveTimeslotTimeZone(
+        nextDayTimeslot as Parameters<typeof resolveTimeslotTimeZone>[0],
+      )
+      const expectedScheduledFor = resolveNextDay9am(start, timeZone).toISOString()
+      expect(deliveriesBeforeCancel.docs[0]?.scheduledFor).toBe(expectedScheduledFor)
+      // Must not schedule from checkout time (tomorrow morning).
+      const bookingDaySchedule = resolveNextDay9am(new Date(), timeZone).toISOString()
+      expect(deliveriesBeforeCancel.docs[0]?.scheduledFor).not.toBe(bookingDaySchedule)
 
       const payloadJobId = (deliveriesBeforeCancel.docs[0] as { payloadJobId?: number })
         ?.payloadJobId

--- a/apps/atnd-me/tests/int/post-booking-email.int.spec.ts
+++ b/apps/atnd-me/tests/int/post-booking-email.int.spec.ts
@@ -505,11 +505,13 @@ describe('Post-booking email integration', () => {
       const timeZone = resolveTimeslotTimeZone(
         nextDayTimeslot as Parameters<typeof resolveTimeslotTimeZone>[0],
       )
-      const expectedScheduledFor = resolveNextDay9am(start, timeZone).toISOString()
-      expect(deliveriesBeforeCancel.docs[0]?.scheduledFor).toBe(expectedScheduledFor)
+      // Compare instants — Payload stores UTC; TZDate.toISOString() may use +01:00.
+      const scheduledForMs = new Date(
+        deliveriesBeforeCancel.docs[0]?.scheduledFor as string,
+      ).getTime()
+      expect(scheduledForMs).toBe(resolveNextDay9am(start, timeZone).getTime())
       // Must not schedule from checkout time (tomorrow morning).
-      const bookingDaySchedule = resolveNextDay9am(new Date(), timeZone).toISOString()
-      expect(deliveriesBeforeCancel.docs[0]?.scheduledFor).not.toBe(bookingDaySchedule)
+      expect(scheduledForMs).not.toBe(resolveNextDay9am(new Date(), timeZone).getTime())
 
       const payloadJobId = (deliveriesBeforeCancel.docs[0] as { payloadJobId?: number })
         ?.payloadJobId

--- a/apps/atnd-me/tests/unit/post-booking-email/batch-and-schedule.test.ts
+++ b/apps/atnd-me/tests/unit/post-booking-email/batch-and-schedule.test.ts
@@ -6,18 +6,28 @@ import {
 } from '@/lib/post-booking-email/batch-context'
 
 describe('resolveNextDay9am', () => {
-  it('schedules 9am the next calendar day in tenant timezone', () => {
-    const confirmedAt = '2026-07-10T22:30:00.000Z'
-    const scheduled = resolveNextDay9am(confirmedAt, 'Europe/Dublin')
+  it('schedules 9am the next calendar day after timeslot start in tenant timezone', () => {
+    // Class at 23:30 Dublin on 10 Jul → send 9am Dublin on 11 Jul (IST = UTC+1)
+    const timeslotStart = '2026-07-10T22:30:00.000Z'
+    const scheduled = resolveNextDay9am(timeslotStart, 'Europe/Dublin')
 
     expect(scheduled.getTime()).toBe(new Date('2026-07-11T08:00:00.000Z').getTime())
   })
 
-  it('uses tenant timezone when booking is late evening US Pacific', () => {
-    const confirmedAt = '2026-07-10T06:00:00.000Z'
-    const scheduled = resolveNextDay9am(confirmedAt, 'America/Los_Angeles')
+  it('uses tenant timezone when class is late evening US Pacific', () => {
+    // 10 Jul 23:00 PDT → send 9am PDT on 11 Jul (= 16:00 UTC)
+    const timeslotStart = '2026-07-11T06:00:00.000Z'
+    const scheduled = resolveNextDay9am(timeslotStart, 'America/Los_Angeles')
 
-    expect(scheduled.getTime()).toBe(new Date('2026-07-10T16:00:00.000Z').getTime())
+    expect(scheduled.getTime()).toBe(new Date('2026-07-11T16:00:00.000Z').getTime())
+  })
+
+  it('anchors to the class day, not the booking/checkout day', () => {
+    // Booked today, class next week Wednesday 14:00 Dublin → Thursday 9am Dublin
+    const timeslotStart = '2026-07-15T13:00:00.000Z'
+    const scheduled = resolveNextDay9am(timeslotStart, 'Europe/Dublin')
+
+    expect(scheduled.getTime()).toBe(new Date('2026-07-16T08:00:00.000Z').getTime())
   })
 })
 


### PR DESCRIPTION
Anchor 9am delivery to the day after the timeslot start, not checkout, so review emails aren't sent early for future classes.