### PR TITLE
fix: hide course places remaining until under 10

### DIFF
--- a/apps/atnd-me/src/components/courses/CourseDetailView.tsx
+++ b/apps/atnd-me/src/components/courses/CourseDetailView.tsx
@@ -3,6 +3,7 @@ import type { DefaultTypedEditorState } from '@payloadcms/richtext-lexical'
 import { currentUser } from '@/lib/auth/context/get-context-props'
 import RichText from '@/components/RichText'
 import { CourseEnrollPanel } from '@/components/courses/CourseEnrollPanel'
+import { coursePlacesLabel } from '@/components/courses/coursePlacesLabel'
 import { formatCourseAccessWindowCopy } from '@/lib/courses/format-course-access-window'
 import { mediaUrl } from '@/components/events/eventPageTypes'
 import type { Media } from '@/payload-types'
@@ -42,6 +43,7 @@ export async function CourseDetailView({
       ? course.maxEnrollments
       : null
   const remaining = max == null ? null : Math.max(0, max - activeEnrollmentCount)
+  const places = coursePlacesLabel(remaining)
   const isOpen = course.status === 'open'
   const cover =
     course.coverImage && typeof course.coverImage === 'object'
@@ -75,20 +77,16 @@ export async function CourseDetailView({
           <h1 className="max-w-3xl text-3xl font-bold tracking-tight text-foreground md:text-4xl">
             {title}
           </h1>
-          {remaining != null ? (
+          {places ? (
             <p
               className={`pt-1 text-sm lg:hidden ${
-                remaining > 0 && remaining <= 6
+                remaining != null && remaining > 0 && remaining <= 6
                   ? 'font-medium text-amber-700 dark:text-amber-400'
                   : 'text-muted-foreground'
               }`}
               data-testid="course-meta-places"
             >
-              {remaining <= 0
-                ? 'Sold out'
-                : remaining === 1
-                  ? '1 place left'
-                  : `${remaining} places left`}
+              {places}
             </p>
           ) : null}
         </header>

--- a/apps/atnd-me/src/components/courses/CourseEnrollPanel.tsx
+++ b/apps/atnd-me/src/components/courses/CourseEnrollPanel.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { isCompleteGuestEmail } from '@/lib/courses/resolve-course-for-purchase'
+import { coursePlacesLabel } from '@/components/courses/coursePlacesLabel'
 
 type CourseEnrollPanelProps = {
   courseId: number
@@ -16,13 +17,6 @@ type CourseEnrollPanelProps = {
   isOpen: boolean
   accessWindowLabel: string | null
   successUrl?: string
-}
-
-function placesLabel(remaining: number | null): string | null {
-  if (remaining == null) return null
-  if (remaining <= 0) return 'Sold out'
-  if (remaining === 1) return '1 place left'
-  return `${remaining} places left`
 }
 
 export function CourseEnrollPanel({
@@ -45,7 +39,7 @@ export function CourseEnrollPanel({
   } | null>(null)
 
   const soldOut = remainingEnrollments != null && remainingEnrollments <= 0
-  const places = placesLabel(remainingEnrollments)
+  const places = coursePlacesLabel(remainingEnrollments)
   const emphasizePlaces =
     remainingEnrollments != null && remainingEnrollments > 0 && remainingEnrollments <= 6
   const classPriceCents = Math.round(price * 100)

--- a/apps/atnd-me/src/components/courses/coursePlacesLabel.ts
+++ b/apps/atnd-me/src/components/courses/coursePlacesLabel.ts
@@ -1,0 +1,14 @@
+/** Only surface remaining capacity when it drops below this (sold out always shows). */
+export const PLACES_REMAINING_DISPLAY_THRESHOLD = 10
+
+/**
+ * Label for course remaining enrollments.
+ * Returns null when capacity is unknown or still plentiful (>= threshold).
+ */
+export function coursePlacesLabel(remaining: number | null): string | null {
+  if (remaining == null) return null
+  if (remaining <= 0) return 'Sold out'
+  if (remaining >= PLACES_REMAINING_DISPLAY_THRESHOLD) return null
+  if (remaining === 1) return '1 place left'
+  return `${remaining} places left`
+}


### PR DESCRIPTION
Avoid showing exact enrollment capacity while plenty of spots remain; still surface sold out and low-availability urgency.