### PR TITLE
fix: include trusted server origin in admin password reset emails

### DIFF
--- a/apps/atnd-me/src/collections/Users/index.ts
+++ b/apps/atnd-me/src/collections/Users/index.ts
@@ -132,14 +132,17 @@ export const Users: CollectionConfig = {
   // link. Build an absolute, trusted origin instead (tenant host when allowed, else platform).
   auth: {
     forgotPassword: {
-      generateEmailHTML: async ({ req, token, user }) => {
+      generateEmailHTML: async (args) => {
+        const req = args?.req
+        const token = args?.token
+        const user = args?.user
         const adminRoute = req?.payload?.config?.routes?.admin || '/admin'
         const resetRoute = req?.payload?.config?.admin?.routes?.reset || '/reset'
         const origin = await resolveTrustedPasswordResetOrigin({
           headers: req?.headers,
           payload: req?.payload,
         })
-        const resetURL = getAbsoluteURL(`${adminRoute}${resetRoute}/${token}`, origin)
+        const resetURL = getAbsoluteURL(`${adminRoute}${resetRoute}/${token ?? ''}`, origin)
         const email = typeof user?.email === 'string' ? user.email : 'there'
         return `You are receiving this because you (or someone else) requested a password reset for ${email}.
 <a href="${resetURL}">${resetURL}</a>

--- a/apps/atnd-me/src/collections/Users/index.ts
+++ b/apps/atnd-me/src/collections/Users/index.ts
@@ -33,6 +33,8 @@ import { getTenantIdForCreateRequest } from '@/utilities/getTenantContext'
 import { cookiesFromHeaders } from '@/utilities/cookiesFromHeaders'
 import { resolveTenantIdForDocumentWrite } from '@/utilities/resolveTenantIdForDocumentWrite'
 import { isSystemUserWrite } from '@/lib/auth/systemUserWriteContext'
+import { getAbsoluteURL } from '@/utilities/getURL'
+import { resolveTrustedPasswordResetOrigin } from '@/utilities/resolveTrustedPasswordResetOrigin'
 import {
   assertAnonymousUserCreateRateLimit,
   normalizeTenantRoles,
@@ -123,6 +125,27 @@ export const Users: CollectionConfig = {
     },
     read: userTenantRead,
     update: userTenantUpdate,
+  },
+  // Merged by payload-auth's Better Auth users builder (`...existingUserCollection.auth`).
+  // Payload's default getRequestOrigin() returns '' when Host is not an exact CORS match
+  // (tenant subdomains / proxy proto mismatch), producing a relative `/admin/reset/<token>`
+  // link. Build an absolute, trusted origin instead (tenant host when allowed, else platform).
+  auth: {
+    forgotPassword: {
+      generateEmailHTML: async ({ req, token, user }) => {
+        const adminRoute = req?.payload?.config?.routes?.admin || '/admin'
+        const resetRoute = req?.payload?.config?.admin?.routes?.reset || '/reset'
+        const origin = await resolveTrustedPasswordResetOrigin({
+          headers: req?.headers,
+          payload: req?.payload,
+        })
+        const resetURL = getAbsoluteURL(`${adminRoute}${resetRoute}/${token}`, origin)
+        const email = typeof user?.email === 'string' ? user.email : 'there'
+        return `You are receiving this because you (or someone else) requested a password reset for ${email}.
+<a href="${resetURL}">${resetURL}</a>
+If you did not request this, you can ignore this email.`
+      },
+    },
   },
   hooks: {
     afterLogin: [afterLoginRedirect],

--- a/apps/atnd-me/src/payload.config.ts
+++ b/apps/atnd-me/src/payload.config.ts
@@ -68,6 +68,11 @@ const disableSchemaPush =
 const disableSchemaPushDuringMigrations = disableSchemaPush && !isPayloadMigrateCliRun
 
 export default buildConfig({
+  // Required for absolute URLs in auth emails (forgot-password reset links).
+  // Without this, Payload's getRequestOrigin() returns '' when the request Host is
+  // not an exact CORS match (tenant subdomains, custom domains, proxy proto mismatch),
+  // and the email link becomes a relative path like `/admin/reset/<token>`.
+  serverURL: getServerSideURL(),
   admin: {
     // Override Payload admin head metadata (title/description/favicon) for white-labeling.
     // Note: this is static config (not request/tenant scoped).

--- a/apps/atnd-me/src/utilities/resolveTrustedPasswordResetOrigin.ts
+++ b/apps/atnd-me/src/utilities/resolveTrustedPasswordResetOrigin.ts
@@ -1,0 +1,95 @@
+import { normalizeCustomDomain } from '@/utilities/validateCustomDomain'
+import {
+  getPlatformHostname,
+  getRequestOrigin,
+  getServerSideURL,
+} from '@/utilities/getURL'
+
+type HeadersLike = Pick<Headers, 'get'>
+
+type PayloadFind = {
+  find: (args: {
+    collection: string
+    where: Record<string, unknown>
+    limit: number
+    depth: number
+    overrideAccess: boolean
+    select?: Record<string, boolean>
+  }) => Promise<{ docs: unknown[] }>
+}
+
+function platformOrigin(): string {
+  try {
+    return new URL(getServerSideURL()).origin
+  } catch {
+    return getServerSideURL().replace(/\/$/, '')
+  }
+}
+
+function isTrustedPlatformHost(hostname: string, platformHost: string): boolean {
+  if (!hostname || !platformHost) return false
+  if (hostname === platformHost) return true
+
+  // Local multi-tenant: {slug}.localhost
+  if (platformHost === 'localhost' || platformHost.endsWith('.localhost')) {
+    return hostname.endsWith('.localhost')
+  }
+
+  // Platform subdomain: {slug}.{platformHost}
+  return hostname.endsWith('.' + platformHost)
+}
+
+/**
+ * Resolve an absolute origin for admin password-reset email links.
+ *
+ * Trusts:
+ * - platform host (NEXT_PUBLIC_SERVER_URL)
+ * - platform subdomains / *.localhost (DNS we control)
+ * - tenant custom domains that exist in the tenants collection
+ *
+ * Anything else falls back to the platform origin (prevents Host-header injection).
+ */
+export async function resolveTrustedPasswordResetOrigin(args: {
+  headers?: HeadersLike | null
+  payload?: PayloadFind | null
+}): Promise<string> {
+  const fallback = platformOrigin()
+  const hostHeader =
+    args.headers?.get('x-forwarded-host')?.split(',')[0]?.trim() ||
+    args.headers?.get('host')?.trim()
+
+  if (!hostHeader) return fallback
+
+  let candidate: URL
+  try {
+    candidate = new URL(getRequestOrigin(args.headers))
+  } catch {
+    return fallback
+  }
+
+  const hostname = candidate.hostname.toLowerCase()
+  const platformHost = getPlatformHostname()?.toLowerCase() || ''
+
+  if (isTrustedPlatformHost(hostname, platformHost)) {
+    return candidate.origin
+  }
+
+  const normalized = normalizeCustomDomain(hostname)
+  if (!normalized || !args.payload) return fallback
+
+  try {
+    const result = await args.payload.find({
+      collection: 'tenants',
+      where: { domain: { equals: normalized } },
+      limit: 1,
+      depth: 0,
+      overrideAccess: true,
+      select: { id: true },
+    })
+    if (result.docs[0]) return candidate.origin
+  } catch {
+    // Fail closed to platform origin
+  }
+
+  return fallback
+}

--- a/apps/atnd-me/src/utilities/resolveTrustedPasswordResetOrigin.ts
+++ b/apps/atnd-me/src/utilities/resolveTrustedPasswordResetOrigin.ts
@@ -8,14 +8,9 @@ import {
 type HeadersLike = Pick<Headers, 'get'>
 
 type PayloadFind = {
-  find: (args: {
-    collection: string
-    where: Record<string, unknown>
-    limit: number
-    depth: number
-    overrideAccess: boolean
-    select?: Record<string, boolean>
-  }) => Promise<{ docs: unknown[] }>
+  // Loose Local API shape so callers can pass `req.payload` without slug generics.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  find: (args: any) => Promise<{ docs: unknown[] }>
 }
 
 function platformOrigin(): string {

--- a/apps/atnd-me/tests/unit/admin-forgot-password-url.test.ts
+++ b/apps/atnd-me/tests/unit/admin-forgot-password-url.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { Users } from '../../src/collections/Users'
+import { resolveTrustedPasswordResetOrigin } from '../../src/utilities/resolveTrustedPasswordResetOrigin'
+
+const ORIGINAL_ENV = { ...process.env }
+
+function generateEmailHTML() {
+  const fn =
+    Users.auth && typeof Users.auth === 'object'
+      ? Users.auth.forgotPassword?.generateEmailHTML
+      : undefined
+  expect(fn).toEqual(expect.any(Function))
+  return fn!
+}
+
+describe('resolveTrustedPasswordResetOrigin', () => {
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV }
+    process.env.NEXT_PUBLIC_SERVER_URL = 'https://atnd-me.com'
+  })
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV }
+  })
+
+  it('falls back to platform for untrusted Host headers', async () => {
+    const origin = await resolveTrustedPasswordResetOrigin({
+      headers: new Headers({ host: 'evil.example' }),
+      payload: { find: vi.fn(async () => ({ docs: [] })) },
+    })
+    expect(origin).toBe('https://atnd-me.com')
+  })
+
+  it('trusts platform subdomains without a DB lookup', async () => {
+    const find = vi.fn(async () => ({ docs: [] }))
+    const origin = await resolveTrustedPasswordResetOrigin({
+      headers: new Headers({
+        host: 'acme.atnd-me.com',
+        'x-forwarded-proto': 'https',
+      }),
+      payload: { find },
+    })
+    expect(origin).toBe('https://acme.atnd-me.com')
+    expect(find).not.toHaveBeenCalled()
+  })
+
+  it('trusts custom domains only when present on a tenant', async () => {
+    const find = vi.fn(async () => ({ docs: [{ id: 1 }] }))
+    const origin = await resolveTrustedPasswordResetOrigin({
+      headers: new Headers({
+        host: 'studio.example.com',
+        'x-forwarded-proto': 'https',
+      }),
+      payload: { find },
+    })
+    expect(origin).toBe('https://studio.example.com')
+    expect(find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collection: 'tenants',
+        where: { domain: { equals: 'studio.example.com' } },
+      }),
+    )
+  })
+
+  it('rejects unknown custom domains', async () => {
+    const origin = await resolveTrustedPasswordResetOrigin({
+      headers: new Headers({
+        host: 'unknown.example.com',
+        'x-forwarded-proto': 'https',
+      }),
+      payload: { find: vi.fn(async () => ({ docs: [] })) },
+    })
+    expect(origin).toBe('https://atnd-me.com')
+  })
+})
+
+describe('Admin forgot-password reset URL', () => {
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV }
+    process.env.NEXT_PUBLIC_SERVER_URL = 'https://atnd-me.com'
+  })
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV }
+  })
+
+  it('uses platform URL for untrusted hosts', async () => {
+    const html = await generateEmailHTML()({
+      token: 'abc123',
+      user: { email: 'admin@example.com' },
+      req: {
+        payload: {
+          config: {
+            routes: { admin: '/admin' },
+            admin: { routes: { reset: '/reset' } },
+          },
+          find: vi.fn(async () => ({ docs: [] })),
+        },
+        headers: new Headers({ host: 'evil.example' }),
+      } as any,
+    })
+
+    expect(html).toContain('https://atnd-me.com/admin/reset/abc123')
+    expect(html).not.toContain('evil.example')
+  })
+
+  it('scopes the reset link to a trusted tenant subdomain', async () => {
+    const html = await generateEmailHTML()({
+      token: 'tok',
+      user: { email: 'admin@example.com' },
+      req: {
+        payload: {
+          config: {
+            routes: { admin: '/admin' },
+            admin: { routes: { reset: '/reset' } },
+          },
+          find: vi.fn(async () => ({ docs: [] })),
+        },
+        headers: new Headers({
+          host: 'acme.atnd-me.com',
+          'x-forwarded-proto': 'https',
+        }),
+      } as any,
+    })
+
+    expect(html).toContain('https://acme.atnd-me.com/admin/reset/tok')
+  })
+})


### PR DESCRIPTION
Payload omitted the host when the request origin was outside exact CORS matches. Build absolute reset links from the tenant subdomain/custom domain when trusted, otherwise fall back to NEXT_PUBLIC_SERVER_URL.