### PR TITLE
Require auth to view existing emergency contacts; auto-load for signed-in users

### DIFF
--- a/apps/atnd-me/package.json
+++ b/apps/atnd-me/package.json
@@ -29,7 +29,7 @@
     "test:int:shard": "cross-env NODE_OPTIONS=\"--no-deprecation --max-old-space-size=6144\" vitest run --config ./vitest.config.mts --shard=${VITEST_SHARD:-1/1}",
     "test:unit": "cross-env NODE_OPTIONS=\"--no-deprecation --import ./scripts/register-payload-auth-loader.mjs\" vitest run --config ./vitest.unit.config.mts",
     "test:e2e:shard": "cross-env CI=1 PW_E2E_MAX_FAILURES=0 PW_TEST_HTML_REPORT_OPEN=never PW_E2E_SKIP_DEFAULT_TENANT_DATA=true NODE_OPTIONS=\"--no-deprecation --import ./scripts/register-payload-auth-loader.mjs\" pnpm exec playwright test --config=playwright.config.ts --shard=${PLAYWRIGHT_SHARD:-1/1}",
-    "db:prepare": "cross-env NODE_OPTIONS=--no-deprecation payload migrate:fresh --force-accept-warning",
+    "db:prepare": "cross-env NODE_OPTIONS=\"--no-deprecation --import ./scripts/register-payload-auth-loader.mjs\" payload migrate:fresh --force-accept-warning",
     "db:fix-users-role": "cross-env NODE_OPTIONS=--no-deprecation pnpm exec tsx scripts/fix-users-role-tenant-admin.ts",
     "seed": "cross-env NODE_OPTIONS=--no-deprecation pnpm exec tsx scripts/seed.ts",
     "ci": "pnpm run payload migrate:fresh --force-accept-warning && sleep 2 && pnpm run build",

--- a/apps/atnd-me/src/app/api/emergency-contacts/route.ts
+++ b/apps/atnd-me/src/app/api/emergency-contacts/route.ts
@@ -2,9 +2,21 @@ import { NextResponse } from 'next/server'
 import { getPayload } from '@/lib/payload'
 import { resolveTenantIdFromServerContext } from '@/access/tenant-scoped'
 import { EMERGENCY_CONTACTS_SLUG } from '@/collections/EmergencyContacts'
-import { findEmergencyContactForUser } from '@/lib/emergency-contacts/lookup'
+import {
+  findEmergencyContactForUser,
+  hasEmergencyContactOnFile,
+  userBelongsToTenant,
+} from '@/lib/emergency-contacts/lookup'
 import { normalizePeopleInput } from '@/lib/emergency-contacts/validate-people'
 import { verifyEmergencyContactToken } from '@/lib/emergency-contacts/verify-token'
+
+function parseUserId(user: unknown): number | null {
+  if (!user || typeof user !== 'object') return null
+  const id = (user as { id?: unknown }).id
+  if (typeof id === 'number' && Number.isFinite(id)) return id
+  if (typeof id === 'string' && /^\d+$/.test(id.trim())) return parseInt(id.trim(), 10)
+  return null
+}
 
 export async function POST(request: Request) {
   try {
@@ -18,36 +30,62 @@ export async function POST(request: Request) {
       people?: unknown
     } | null
 
-    const token = typeof body?.token === 'string' ? body.token : ''
-    if (!token) {
-      return NextResponse.json({ error: 'Verification token is required.' }, { status: 401 })
-    }
-
-    let verified: ReturnType<typeof verifyEmergencyContactToken>
-    try {
-      verified = verifyEmergencyContactToken(token)
-    } catch {
-      return NextResponse.json(
-        { error: 'Verification expired or invalid. Please verify your email again.' },
-        { status: 401 },
-      )
-    }
-
-    if (verified.tenantId !== tenantId) {
-      return NextResponse.json({ error: 'Verification does not match this studio.' }, { status: 403 })
-    }
-
     const { people, error } = normalizePeopleInput(body?.people)
     if (error) {
       return NextResponse.json({ error }, { status: 400 })
     }
 
     const payload = await getPayload()
-    const existing = await findEmergencyContactForUser(payload, verified.userId, tenantId)
+    const authResult = await payload.auth({ headers: request.headers })
+    const sessionUserId = parseUserId(authResult?.user)
+
+    let userId: number
+
+    if (sessionUserId != null) {
+      if (!(await userBelongsToTenant(payload, sessionUserId, tenantId))) {
+        return NextResponse.json({ error: 'Account does not belong to this studio.' }, { status: 403 })
+      }
+      userId = sessionUserId
+    } else {
+      const token = typeof body?.token === 'string' ? body.token : ''
+      if (!token) {
+        return NextResponse.json({ error: 'Verification token is required.' }, { status: 401 })
+      }
+
+      let verified: ReturnType<typeof verifyEmergencyContactToken>
+      try {
+        verified = verifyEmergencyContactToken(token)
+      } catch {
+        return NextResponse.json(
+          { error: 'Verification expired or invalid. Please verify your email again.' },
+          { status: 401 },
+        )
+      }
+
+      if (verified.tenantId !== tenantId) {
+        return NextResponse.json({ error: 'Verification does not match this studio.' }, { status: 403 })
+      }
+
+      userId = verified.userId
+
+      const existingForToken = await findEmergencyContactForUser(payload, userId, tenantId)
+      if (hasEmergencyContactOnFile(existingForToken)) {
+        return NextResponse.json(
+          {
+            error:
+              'Emergency contacts are already on file for this account. Sign in to view or update them.',
+            requiresAuth: true,
+          },
+          { status: 403 },
+        )
+      }
+    }
+
+    const existing = await findEmergencyContactForUser(payload, userId, tenantId)
     const completedAt = existing?.completedAt ?? new Date().toISOString()
 
     const data = {
-      user: verified.userId,
+      user: userId,
       tenant: tenantId,
       status: 'complete' as const,
       people,

--- a/apps/atnd-me/src/app/api/emergency-contacts/verify-email/route.ts
+++ b/apps/atnd-me/src/app/api/emergency-contacts/verify-email/route.ts
@@ -1,12 +1,15 @@
+import { headers } from 'next/headers'
 import { NextResponse } from 'next/server'
 import { getPayload } from '@/lib/payload'
 import { resolveTenantIdFromServerContext } from '@/access/tenant-scoped'
+import { buildAuthCallbackURL, sanitizeRedirectPath } from '@/lib/emergency-contacts/auth-redirect'
 import {
   findEmergencyContactForUser,
   findTenantUserByEmail,
   hasEmergencyContactOnFile,
 } from '@/lib/emergency-contacts/lookup'
 import { buildEmergencyContactVerifyToken } from '@/lib/emergency-contacts/verify-token'
+import { getTenantContext } from '@/utilities/getTenantContext'
 
 export async function POST(request: Request) {
   try {
@@ -15,7 +18,10 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'No tenant context for this request.' }, { status: 400 })
     }
 
-    const body = (await request.json().catch(() => null)) as { email?: unknown } | null
+    const body = (await request.json().catch(() => null)) as {
+      email?: unknown
+      redirectTo?: unknown
+    } | null
     const email = typeof body?.email === 'string' ? body.email.trim().toLowerCase() : ''
     if (!email || !email.includes('@')) {
       return NextResponse.json({ error: 'Enter a valid email address.' }, { status: 400 })
@@ -32,14 +38,32 @@ export async function POST(request: Request) {
 
     const existing = await findEmergencyContactForUser(payload, user.id, tenantId)
     if (hasEmergencyContactOnFile(existing)) {
-      return NextResponse.json(
-        {
-          error:
-            'Emergency contacts are already on file for this account. Sign in to view or update them.',
-          requiresAuth: true,
+      if (!payload.betterAuth?.api?.signInMagicLink) {
+        return NextResponse.json({ error: 'Auth is not configured.' }, { status: 500 })
+      }
+
+      const requestHeaders = await headers()
+      const tenant = await getTenantContext(payload, { headers: requestHeaders })
+      const redirectTo = sanitizeRedirectPath(body?.redirectTo)
+      const callbackURL = buildAuthCallbackURL({
+        redirectTo,
+        tenant,
+        headers: requestHeaders,
+        serverUrlFallback: process.env.NEXT_PUBLIC_SERVER_URL || process.env.SERVER_URL,
+      })
+
+      await payload.betterAuth.api.signInMagicLink({
+        body: {
+          email: user.email,
+          callbackURL,
         },
-        { status: 403 },
-      )
+        headers: requestHeaders,
+      })
+
+      return NextResponse.json({
+        requiresAuth: true,
+        magicLinkSent: true,
+      })
     }
 
     const token = buildEmergencyContactVerifyToken(user.id, tenantId, user.email)

--- a/apps/atnd-me/src/app/api/emergency-contacts/verify-email/route.ts
+++ b/apps/atnd-me/src/app/api/emergency-contacts/verify-email/route.ts
@@ -1,4 +1,3 @@
-import { headers } from 'next/headers'
 import { NextResponse } from 'next/server'
 import { getPayload } from '@/lib/payload'
 import { resolveTenantIdFromServerContext } from '@/access/tenant-scoped'
@@ -42,7 +41,7 @@ export async function POST(request: Request) {
         return NextResponse.json({ error: 'Auth is not configured.' }, { status: 500 })
       }
 
-      const requestHeaders = await headers()
+      const requestHeaders = request.headers
       const tenant = await getTenantContext(payload, { headers: requestHeaders })
       const redirectTo = sanitizeRedirectPath(body?.redirectTo)
       const callbackURL = buildAuthCallbackURL({

--- a/apps/atnd-me/src/app/api/emergency-contacts/verify-email/route.ts
+++ b/apps/atnd-me/src/app/api/emergency-contacts/verify-email/route.ts
@@ -1,7 +1,11 @@
 import { NextResponse } from 'next/server'
 import { getPayload } from '@/lib/payload'
 import { resolveTenantIdFromServerContext } from '@/access/tenant-scoped'
-import { findEmergencyContactForUser, findTenantUserByEmail } from '@/lib/emergency-contacts/lookup'
+import {
+  findEmergencyContactForUser,
+  findTenantUserByEmail,
+  hasEmergencyContactOnFile,
+} from '@/lib/emergency-contacts/lookup'
 import { buildEmergencyContactVerifyToken } from '@/lib/emergency-contacts/verify-token'
 
 export async function POST(request: Request) {
@@ -26,8 +30,19 @@ export async function POST(request: Request) {
       )
     }
 
-    const token = buildEmergencyContactVerifyToken(user.id, tenantId, user.email)
     const existing = await findEmergencyContactForUser(payload, user.id, tenantId)
+    if (hasEmergencyContactOnFile(existing)) {
+      return NextResponse.json(
+        {
+          error:
+            'Emergency contacts are already on file for this account. Sign in to view or update them.',
+          requiresAuth: true,
+        },
+        { status: 403 },
+      )
+    }
+
+    const token = buildEmergencyContactVerifyToken(user.id, tenantId, user.email)
 
     return NextResponse.json({
       token,
@@ -36,12 +51,7 @@ export async function POST(request: Request) {
         email: user.email,
         name: user.name,
       },
-      existing: existing
-        ? {
-            status: existing.status,
-            people: existing.people,
-          }
-        : null,
+      existing: null,
     })
   } catch (error) {
     console.error('[emergency-contacts/verify-email]', error)

--- a/apps/atnd-me/src/blocks/EmergencyContactForm/EmergencyContactForm.client.tsx
+++ b/apps/atnd-me/src/blocks/EmergencyContactForm/EmergencyContactForm.client.tsx
@@ -1,19 +1,16 @@
 'use client'
 
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
 import { useMemo, useState } from 'react'
 import { Button } from '@repo/ui/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import ClientRichText from '@/components/RichText/Client'
 import type { EmergencyContactPerson, EmergencyContactPersonType } from '@/lib/emergency-contacts/types'
+import type { EmergencyContactSessionUser } from '@/lib/emergency-contacts/resolve-session-user'
 
 type IntroData = Parameters<typeof ClientRichText>[0]['data']
-
-type VerifiedUser = {
-  id: number
-  email: string
-  name: string | null
-}
 
 function emptyContact() {
   return { name: '', phone: '', relationship: '' }
@@ -32,20 +29,37 @@ function emptyPerson(overrides?: Partial<EmergencyContactPerson>): EmergencyCont
 export type EmergencyContactFormClientProps = {
   heading?: string | null
   intro?: IntroData | null
+  sessionUser?: EmergencyContactSessionUser | null
+  initialPeople?: EmergencyContactPerson[] | null
 }
 
-export function EmergencyContactFormClient({ heading, intro }: EmergencyContactFormClientProps) {
-  const [email, setEmail] = useState('')
+export function EmergencyContactFormClient({
+  heading,
+  intro,
+  sessionUser = null,
+  initialPeople = null,
+}: EmergencyContactFormClientProps) {
+  const pathname = usePathname()
+  const isAuthenticated = Boolean(sessionUser)
+
+  const [email, setEmail] = useState(sessionUser?.email ?? '')
   const [verifyError, setVerifyError] = useState<string | null>(null)
+  const [requiresAuth, setRequiresAuth] = useState(false)
   const [verifyLoading, setVerifyLoading] = useState(false)
   const [token, setToken] = useState<string | null>(null)
-  const [verifiedUser, setVerifiedUser] = useState<VerifiedUser | null>(null)
-  const [people, setPeople] = useState<EmergencyContactPerson[]>([emptyPerson()])
+  const [verifiedUser, setVerifiedUser] = useState<EmergencyContactSessionUser | null>(
+    sessionUser,
+  )
+  const [people, setPeople] = useState<EmergencyContactPerson[]>(
+    initialPeople?.length ? initialPeople : [emptyPerson()],
+  )
   const [saveError, setSaveError] = useState<string | null>(null)
   const [saveSuccess, setSaveSuccess] = useState(false)
   const [saveLoading, setSaveLoading] = useState(false)
 
-  const unlocked = Boolean(token && verifiedUser)
+  const unlocked = isAuthenticated || Boolean(token && verifiedUser)
+
+  const signInHref = `/auth/sign-in?redirectTo=${encodeURIComponent(pathname || '/')}`
 
   const title = useMemo(
     () => (typeof heading === 'string' && heading.trim() ? heading.trim() : 'Emergency contacts'),
@@ -55,6 +69,7 @@ export function EmergencyContactFormClient({ heading, intro }: EmergencyContactF
   const handleVerify = async (e: React.FormEvent) => {
     e.preventDefault()
     setVerifyError(null)
+    setRequiresAuth(false)
     setSaveSuccess(false)
     setVerifyLoading(true)
     try {
@@ -67,6 +82,7 @@ export function EmergencyContactFormClient({ heading, intro }: EmergencyContactF
       const data = await res.json().catch(() => ({}))
       if (!res.ok) {
         setVerifyError(typeof data.error === 'string' ? data.error : 'Unable to verify email.')
+        setRequiresAuth(data.requiresAuth === true)
         setToken(null)
         setVerifiedUser(null)
         return
@@ -74,18 +90,12 @@ export function EmergencyContactFormClient({ heading, intro }: EmergencyContactF
 
       setToken(typeof data.token === 'string' ? data.token : null)
       setVerifiedUser(data.user ?? null)
-
-      const existingPeople = data.existing?.people
-      if (Array.isArray(existingPeople) && existingPeople.length > 0) {
-        setPeople(existingPeople as EmergencyContactPerson[])
-      } else {
-        setPeople([
-          emptyPerson({
-            fullName: typeof data.user?.name === 'string' ? data.user.name : '',
-            personType: 'self',
-          }),
-        ])
-      }
+      setPeople([
+        emptyPerson({
+          fullName: typeof data.user?.name === 'string' ? data.user.name : '',
+          personType: 'self',
+        }),
+      ])
     } catch {
       setVerifyError('Unable to verify email.')
       setToken(null)
@@ -117,7 +127,7 @@ export function EmergencyContactFormClient({ heading, intro }: EmergencyContactF
 
   const handleSave = async (e: React.FormEvent) => {
     e.preventDefault()
-    if (!token) return
+    if (!isAuthenticated && !token) return
     setSaveError(null)
     setSaveSuccess(false)
     setSaveLoading(true)
@@ -126,7 +136,10 @@ export function EmergencyContactFormClient({ heading, intro }: EmergencyContactF
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
-        body: JSON.stringify({ token, people }),
+        body: JSON.stringify({
+          ...(token ? { token } : {}),
+          people,
+        }),
       })
       const data = await res.json().catch(() => ({}))
       if (!res.ok) {
@@ -148,35 +161,53 @@ export function EmergencyContactFormClient({ heading, intro }: EmergencyContactF
         {intro ? <ClientRichText data={intro} enableGutter={false} /> : null}
       </div>
 
-      <form onSubmit={handleVerify} className="space-y-4 rounded-lg border p-4">
-        <div className="space-y-2">
-          <Label htmlFor="emergency-contact-email">Your account email</Label>
-          <Input
-            id="emergency-contact-email"
-            type="email"
-            autoComplete="email"
-            required
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            placeholder="you@example.com"
-            disabled={verifyLoading}
-          />
+      {isAuthenticated ? (
+        <div className="space-y-2 rounded-lg border p-4">
+          <p className="text-sm font-medium">Signed in as {sessionUser?.email}</p>
+          {sessionUser?.name ? (
+            <p className="text-sm text-muted-foreground">{sessionUser.name}</p>
+          ) : null}
           <p className="text-sm text-muted-foreground">
-            Enter the email on your booking account. Contact details unlock after we confirm it
-            exists.
+            Your saved emergency contacts are shown below. Update them and save when you are done.
           </p>
         </div>
-        {verifyError ? <p className="text-sm text-destructive">{verifyError}</p> : null}
-        {verifiedUser ? (
-          <p className="text-sm text-muted-foreground">
-            Verified: {verifiedUser.email}
-            {verifiedUser.name ? ` (${verifiedUser.name})` : ''}
-          </p>
-        ) : null}
-        <Button type="submit" disabled={verifyLoading}>
-          {verifyLoading ? 'Checking…' : unlocked ? 'Re-check email' : 'Continue'}
-        </Button>
-      </form>
+      ) : (
+        <form onSubmit={handleVerify} className="space-y-4 rounded-lg border p-4">
+          <div className="space-y-2">
+            <Label htmlFor="emergency-contact-email">Your account email</Label>
+            <Input
+              id="emergency-contact-email"
+              type="email"
+              autoComplete="email"
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="you@example.com"
+              disabled={verifyLoading}
+            />
+            <p className="text-sm text-muted-foreground">
+              Enter the email on your booking account. If you have not submitted emergency contacts
+              yet, you can continue after we confirm your email. If you already have contacts on
+              file, you will need to sign in.
+            </p>
+          </div>
+          {verifyError ? <p className="text-sm text-destructive">{verifyError}</p> : null}
+          {requiresAuth ? (
+            <Button asChild>
+              <Link href={signInHref}>Sign in to view your emergency contacts</Link>
+            </Button>
+          ) : null}
+          {verifiedUser ? (
+            <p className="text-sm text-muted-foreground">
+              Verified: {verifiedUser.email}
+              {verifiedUser.name ? ` (${verifiedUser.name})` : ''}
+            </p>
+          ) : null}
+          <Button type="submit" disabled={verifyLoading}>
+            {verifyLoading ? 'Checking…' : unlocked ? 'Re-check email' : 'Continue'}
+          </Button>
+        </form>
+      )}
 
       {unlocked ? (
         <form onSubmit={handleSave} className="space-y-6">

--- a/apps/atnd-me/src/blocks/EmergencyContactForm/EmergencyContactForm.client.tsx
+++ b/apps/atnd-me/src/blocks/EmergencyContactForm/EmergencyContactForm.client.tsx
@@ -1,7 +1,6 @@
 'use client'
 
-import Link from 'next/link'
-import { usePathname } from 'next/navigation'
+import { usePathname, useRouter } from 'next/navigation'
 import { useMemo, useState } from 'react'
 import { Button } from '@repo/ui/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -40,11 +39,11 @@ export function EmergencyContactFormClient({
   initialPeople = null,
 }: EmergencyContactFormClientProps) {
   const pathname = usePathname()
+  const router = useRouter()
   const isAuthenticated = Boolean(sessionUser)
 
   const [email, setEmail] = useState(sessionUser?.email ?? '')
   const [verifyError, setVerifyError] = useState<string | null>(null)
-  const [requiresAuth, setRequiresAuth] = useState(false)
   const [verifyLoading, setVerifyLoading] = useState(false)
   const [token, setToken] = useState<string | null>(null)
   const [verifiedUser, setVerifiedUser] = useState<EmergencyContactSessionUser | null>(
@@ -59,8 +58,6 @@ export function EmergencyContactFormClient({
 
   const unlocked = isAuthenticated || Boolean(token && verifiedUser)
 
-  const signInHref = `/auth/sign-in?redirectTo=${encodeURIComponent(pathname || '/')}`
-
   const title = useMemo(
     () => (typeof heading === 'string' && heading.trim() ? heading.trim() : 'Emergency contacts'),
     [heading],
@@ -69,7 +66,6 @@ export function EmergencyContactFormClient({
   const handleVerify = async (e: React.FormEvent) => {
     e.preventDefault()
     setVerifyError(null)
-    setRequiresAuth(false)
     setSaveSuccess(false)
     setVerifyLoading(true)
     try {
@@ -77,12 +73,15 @@ export function EmergencyContactFormClient({
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
-        body: JSON.stringify({ email }),
+        body: JSON.stringify({ email, redirectTo: pathname || '/' }),
       })
       const data = await res.json().catch(() => ({}))
+      if (data.magicLinkSent === true) {
+        router.push('/magic-link-sent')
+        return
+      }
       if (!res.ok) {
         setVerifyError(typeof data.error === 'string' ? data.error : 'Unable to verify email.')
-        setRequiresAuth(data.requiresAuth === true)
         setToken(null)
         setVerifiedUser(null)
         return
@@ -188,15 +187,10 @@ export function EmergencyContactFormClient({
             <p className="text-sm text-muted-foreground">
               Enter the email on your booking account. If you have not submitted emergency contacts
               yet, you can continue after we confirm your email. If you already have contacts on
-              file, you will need to sign in.
+              file, we will email you a magic link to sign in.
             </p>
           </div>
           {verifyError ? <p className="text-sm text-destructive">{verifyError}</p> : null}
-          {requiresAuth ? (
-            <Button asChild>
-              <Link href={signInHref}>Sign in to view your emergency contacts</Link>
-            </Button>
-          ) : null}
           {verifiedUser ? (
             <p className="text-sm text-muted-foreground">
               Verified: {verifiedUser.email}

--- a/apps/atnd-me/src/blocks/EmergencyContactForm/async-block.tsx
+++ b/apps/atnd-me/src/blocks/EmergencyContactForm/async-block.tsx
@@ -1,4 +1,11 @@
 import { resolveTenantIdFromServerContext } from '@/access/tenant-scoped'
+import { currentUser, getSession } from '@/lib/auth/context/get-context-props'
+import { findEmergencyContactForUser } from '@/lib/emergency-contacts/lookup'
+import {
+  initialPeopleForSession,
+  parseEmergencyContactSessionUser,
+} from '@/lib/emergency-contacts/resolve-session-user'
+import { getPayload } from '@/lib/payload'
 import { EmergencyContactFormClient } from './EmergencyContactForm.client'
 
 type EmergencyContactFormBlockProps = {
@@ -17,10 +24,22 @@ export async function EmergencyContactFormAsync(props: EmergencyContactFormBlock
     )
   }
 
+  const session = await getSession()
+  const sessionUser = parseEmergencyContactSessionUser(session?.user ?? (await currentUser()))
+
+  let initialPeople = null
+  if (sessionUser) {
+    const payload = await getPayload()
+    const existing = await findEmergencyContactForUser(payload, sessionUser.id, tenantId)
+    initialPeople = initialPeopleForSession(existing, sessionUser.name)
+  }
+
   return (
     <EmergencyContactFormClient
       heading={props.heading}
       intro={props.intro as Parameters<typeof EmergencyContactFormClient>[0]['intro']}
+      sessionUser={sessionUser}
+      initialPeople={initialPeople}
     />
   )
 }

--- a/apps/atnd-me/src/lib/emergency-contacts/auth-redirect.ts
+++ b/apps/atnd-me/src/lib/emergency-contacts/auth-redirect.ts
@@ -1,0 +1,33 @@
+import { getAbsoluteURL, getRequestOrigin, getTenantSiteURL } from '@/utilities/getURL'
+
+type TenantURLSource = {
+  slug?: string | null
+  domain?: string | null
+}
+
+/** Restrict callback paths to same-site relative URLs. */
+export function sanitizeRedirectPath(value: unknown, fallback = '/'): string {
+  if (typeof value !== 'string') return fallback
+  const trimmed = value.trim()
+  if (!trimmed.startsWith('/') || trimmed.startsWith('//')) return fallback
+  return trimmed
+}
+
+export function buildAuthCallbackURL(args: {
+  redirectTo: string
+  tenant?: TenantURLSource | null
+  headers?: Headers | null
+  serverUrlFallback?: string
+}): string {
+  const path = sanitizeRedirectPath(args.redirectTo)
+  const base =
+    args.tenant != null && (args.tenant.domain != null || args.tenant.slug != null)
+      ? getTenantSiteURL(args.tenant, args.headers)
+      : getRequestOrigin(args.headers) || args.serverUrlFallback
+
+  if (!base) {
+    throw new Error('Missing request origin for magic link callbackURL')
+  }
+
+  return getAbsoluteURL(path, base)
+}

--- a/apps/atnd-me/src/lib/emergency-contacts/lookup.ts
+++ b/apps/atnd-me/src/lib/emergency-contacts/lookup.ts
@@ -72,6 +72,40 @@ export async function findEmergencyContactForUser(
   return toEmergencyContactSummary(doc as unknown as Record<string, unknown>)
 }
 
+/** True when the account already has a saved emergency-contact record for this tenant. */
+export function hasEmergencyContactOnFile(
+  existing: EmergencyContactRecordSummary | null,
+): boolean {
+  return existing !== null
+}
+
+export async function userBelongsToTenant(
+  payload: Payload,
+  userId: number,
+  tenantId: number,
+): Promise<boolean> {
+  const found = await payload.findByID({
+    collection: 'users',
+    id: userId,
+    depth: 0,
+    overrideAccess: true,
+  })
+
+  if (!found) return false
+
+  const doc = found as unknown as Record<string, unknown>
+  const registrationTenant = relationId(doc.registrationTenant)
+  if (registrationTenant === tenantId) return true
+
+  const tenants = doc.tenants
+  if (!Array.isArray(tenants)) return false
+
+  return tenants.some((entry) => {
+    if (!entry || typeof entry !== 'object') return false
+    return relationId((entry as Record<string, unknown>).tenant) === tenantId
+  })
+}
+
 export function toEmergencyContactSummary(doc: Record<string, unknown>): EmergencyContactRecordSummary {
   const userId = relationId(doc.user) ?? 0
   const peopleRaw = Array.isArray(doc.people) ? doc.people : []

--- a/apps/atnd-me/src/lib/emergency-contacts/resolve-session-user.ts
+++ b/apps/atnd-me/src/lib/emergency-contacts/resolve-session-user.ts
@@ -1,0 +1,44 @@
+import type { EmergencyContactPerson } from './types'
+import type { EmergencyContactRecordSummary } from './types'
+
+export type EmergencyContactSessionUser = {
+  id: number
+  email: string
+  name: string | null
+}
+
+export function parseEmergencyContactSessionUser(user: unknown): EmergencyContactSessionUser | null {
+  if (!user || typeof user !== 'object') return null
+  const u = user as { id?: unknown; email?: unknown; name?: unknown }
+  const email = typeof u.email === 'string' ? u.email.trim().toLowerCase() : ''
+  if (!email) return null
+
+  let id: number | null = null
+  if (typeof u.id === 'number' && Number.isFinite(u.id)) id = u.id
+  else if (typeof u.id === 'string' && /^\d+$/.test(u.id.trim())) id = parseInt(u.id.trim(), 10)
+  if (id == null || id <= 0) return null
+
+  return {
+    id,
+    email,
+    name: typeof u.name === 'string' ? u.name : null,
+  }
+}
+
+export function initialPeopleForSession(
+  existing: EmergencyContactRecordSummary | null,
+  userName: string | null,
+): EmergencyContactPerson[] {
+  if (existing?.people?.length) {
+    return existing.people
+  }
+
+  return [
+    {
+      fullName: userName?.trim() ?? '',
+      personType: 'self',
+      contacts: [{ name: '', phone: '', relationship: '' }],
+      medicalNotes: '',
+    },
+  ]
+}

--- a/apps/atnd-me/tests/unit/emergency-contacts/verify-and-validate.test.ts
+++ b/apps/atnd-me/tests/unit/emergency-contacts/verify-and-validate.test.ts
@@ -6,6 +6,10 @@ import {
 import { normalizePeopleInput } from '@/lib/emergency-contacts/validate-people'
 import { hasEmergencyContactOnFile } from '@/lib/emergency-contacts/lookup'
 import {
+  buildAuthCallbackURL,
+  sanitizeRedirectPath,
+} from '@/lib/emergency-contacts/auth-redirect'
+import {
   initialPeopleForSession,
   parseEmergencyContactSessionUser,
 } from '@/lib/emergency-contacts/resolve-session-user'
@@ -50,6 +54,36 @@ describe('normalizePeopleInput', () => {
     expect(
       normalizePeopleInput([{ fullName: 'Emma', personType: 'child', contacts: [] }]).error,
     ).toMatch(/at least one emergency contact/i)
+  })
+})
+
+describe('sanitizeRedirectPath', () => {
+  it('accepts safe relative paths', () => {
+    expect(sanitizeRedirectPath('/emergency-contacts')).toBe('/emergency-contacts')
+  })
+
+  it('rejects open redirects', () => {
+    expect(sanitizeRedirectPath('https://evil.example')).toBe('/')
+    expect(sanitizeRedirectPath('//evil.example')).toBe('/')
+  })
+})
+
+describe('buildAuthCallbackURL', () => {
+  it('builds a tenant-scoped callback URL from request origin when no tenant slug', () => {
+    const url = buildAuthCallbackURL({
+      redirectTo: '/emergency-contacts',
+      headers: new Headers({ host: 'acme.atnd-me.com', 'x-forwarded-proto': 'https' }),
+    })
+    expect(url).toBe('https://acme.atnd-me.com/emergency-contacts')
+  })
+
+  it('builds a tenant subdomain callback URL when slug is provided', () => {
+    const url = buildAuthCallbackURL({
+      redirectTo: '/emergency-contacts',
+      tenant: { slug: 'acme', domain: 'studio.example.com' },
+      headers: new Headers({ host: 'ignored.example.com', 'x-forwarded-proto': 'https' }),
+    })
+    expect(url).toBe('https://studio.example.com/emergency-contacts')
   })
 })
 

--- a/apps/atnd-me/tests/unit/emergency-contacts/verify-and-validate.test.ts
+++ b/apps/atnd-me/tests/unit/emergency-contacts/verify-and-validate.test.ts
@@ -4,6 +4,11 @@ import {
   verifyEmergencyContactToken,
 } from '@/lib/emergency-contacts/verify-token'
 import { normalizePeopleInput } from '@/lib/emergency-contacts/validate-people'
+import { hasEmergencyContactOnFile } from '@/lib/emergency-contacts/lookup'
+import {
+  initialPeopleForSession,
+  parseEmergencyContactSessionUser,
+} from '@/lib/emergency-contacts/resolve-session-user'
 
 describe('emergency contact verify token', () => {
   it('round-trips a valid token', () => {
@@ -45,5 +50,70 @@ describe('normalizePeopleInput', () => {
     expect(
       normalizePeopleInput([{ fullName: 'Emma', personType: 'child', contacts: [] }]).error,
     ).toMatch(/at least one emergency contact/i)
+  })
+})
+
+describe('hasEmergencyContactOnFile', () => {
+  it('returns true when a record exists', () => {
+    expect(
+      hasEmergencyContactOnFile({
+        id: 1,
+        userId: 2,
+        status: 'complete',
+        people: [],
+      }),
+    ).toBe(true)
+  })
+
+  it('returns false when no record exists', () => {
+    expect(hasEmergencyContactOnFile(null)).toBe(false)
+  })
+})
+
+describe('parseEmergencyContactSessionUser', () => {
+  it('parses a valid session user', () => {
+    expect(
+      parseEmergencyContactSessionUser({
+        id: 12,
+        email: 'Parent@Example.com',
+        name: 'Parent',
+      }),
+    ).toEqual({
+      id: 12,
+      email: 'parent@example.com',
+      name: 'Parent',
+    })
+  })
+
+  it('rejects invalid users', () => {
+    expect(parseEmergencyContactSessionUser(null)).toBeNull()
+    expect(parseEmergencyContactSessionUser({ id: 1 })).toBeNull()
+  })
+})
+
+describe('initialPeopleForSession', () => {
+  it('returns existing people when present', () => {
+    const people = initialPeopleForSession(
+      {
+        id: 1,
+        userId: 2,
+        status: 'complete',
+        people: [
+          {
+            fullName: 'Emma',
+            personType: 'child',
+            contacts: [{ name: 'Dad', phone: '123', relationship: 'father' }],
+          },
+        ],
+      },
+      'Parent',
+    )
+    expect(people[0]?.fullName).toBe('Emma')
+  })
+
+  it('returns a blank self person when no record exists', () => {
+    const people = initialPeopleForSession(null, 'Parent')
+    expect(people[0]?.fullName).toBe('Parent')
+    expect(people[0]?.personType).toBe('self')
   })
 })

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "ci:atnd-me:unit": "turbo run test:unit --filter=atnd-me",
     "ci:atnd-me:int": "turbo run test:int:shard --filter=atnd-me",
     "ci:atnd-me:e2e": "turbo run test:e2e:shard --filter=atnd-me",
-    "ci:atnd-me:db": "turbo run db:prepare --filter=atnd-me",
+    "ci:atnd-me:db": "turbo run build --filter=atnd-me^... && pnpm --filter atnd-me run db:prepare",
     "ci:atnd-me:build": "turbo run build --filter=atnd-me",
     "test:verbose:unit:atnd-me": "turbo run test:unit --filter=atnd-me -- --reporter=verbose",
     "test:verbose:packages": "turbo run test --filter='./packages/*' --continue --concurrency=2 -- --reporter=verbose",

--- a/turbo.json
+++ b/turbo.json
@@ -121,6 +121,7 @@
     "db:prepare": {
       "dependsOn": ["^build"],
       "env": ["DATABASE_URI", "PAYLOAD_SECRET", "CI", "NODE_ENV"],
+      "inputs": ["$TURBO_DEFAULT$"],
       "cache": false
     },
     "test:e2e": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the Emergency Contact Form block so unauthenticated users can only create new emergency contact records, while viewing or editing existing records requires authentication.

## Changes

### Unauthenticated users
- Email verification still unlocks the form for **new** submissions (no existing record for that account/tenant).
- If emergency contacts are already on file, the API sends a **magic link** to the user's email (with `callbackURL` back to the current page) and the browser is redirected to `/magic-link-sent`.
- First-time submissions still use the email verification token to save.

### Authenticated users
- Server-side block loader resolves the session user and pre-fills saved emergency contacts automatically.
- Email verification step is skipped; the form is unlocked immediately with a "Signed in as …" banner.
- Save endpoint accepts session auth (no verification token required) in addition to the existing token path for first-time guest submissions.

### Supporting updates
- Added helpers: `hasEmergencyContactOnFile`, `userBelongsToTenant`, `parseEmergencyContactSessionUser`, `initialPeopleForSession`, `sanitizeRedirectPath`, `buildAuthCallbackURL`.
- Unit tests for new helpers and auth gating behavior.

## Testing
- `pnpm run test:unit -- tests/unit/emergency-contacts/verify-and-validate.test.ts` — pass
- `pnpm run check-types` — pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02903-bf1f-7a99-8577-d0c4a2e1e6a7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02903-bf1f-7a99-8577-d0c4a2e1e6a7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

